### PR TITLE
MacOS README.md update with step-by-step (for internal betanet)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,167 +1,206 @@
 # nearup
+
 Public scripts to launch near devnet, betanet and testnet node
 
 # Usage
+
 ## Install
+
 ```
 curl --proto '=https' --tlsv1.2 -sSfL https://up.near.dev | python3
 ```
+
 Nearup automatically adds itself to PATH: restart the terminal, or issue the command `source ~/.profile`.
 On each run, nearup self-updates to the latest version.
 
-## Start devnet, betanet, testnet
-```
-nearup devnet
-nearup betanet
-nearup testnet
-```
-Where `devnet` is the nightly release; `betanet` is the weekly release; `testnet` is the stable release.
+## Start
 
-## Start devnet, betanet, testnet with officially compiled binary
-Currently Linux only:
+### Using Docker (recommended for fast onboarding)
+
+```
+nearup betanet
+```
+
+Where `betanet` is the weekly release; use `devnet` for the nightly releases, or `testnet` for the stable releases.
+
+### Using Officially Compiled Binary (recommended for running on servers)
+
+Currently, officially compiled binaries are only available for Linux:
+
 ```
 nearup betanet --nodocker
 ```
-Replace `betanet` with `devnet` or `testnet` if you want to use a different network
 
-## Start devnet, betanet, testnet with local nearcore
-Compile in nearcore/ with `make release` or `make debug` first
+Replace `betanet` with `devnet` or `testnet` if you want to use a different network.
+
+### Using Locally Compiled Binary (recommended for security critical validators or development needs)
+
+Clone and compile nearcore with `make release` or `make debug` first.
+
 ```
-nearup {devnet, betanet, testnet} --nodocker --binary-path path/to/nearcore/target/{debug, release}
+nearup betanet --nodocker --binary-path path/to/nearcore/target/{debug, release}
 ```
 
-## Stop a running node
+Replace `betanet` with `devnet` or `testnet` if you want to use a different network.
+
+## Stop a Running Node
+
 ```
 nearup stop
 ```
 
-## Additional options
+## Additional Options
+
 ```
-nearup {devnet, betanet, testnet} --help
+nearup betanet --help
 ```
 
-## Run NEAR betanet on macOS
+## Get Started Guides
+
+### Run NEAR betanet on macOS
+
 nearup runs also on Apple macOS. Requirements:
-- At least 40GB of storage space available
-- [Install Docker for Mac by using this link](https://hub.docker.com/editions/community/docker-ce-desktop-mac/)
-- Xcode Command Line Tools (installation will start automatically during the process)
-- If you are not using macOS 10.15 Catalina, [install Python3 from this link](https://www.python.org/downloads/)
+* At least 40GB of storage space available
+* Install Docker for Mac by using this [link](https://hub.docker.com/editions/community/docker-ce-desktop-mac/)
+* Xcode Command Line Tools (installation will start automatically during the process)
+* If you are not using macOS 10.15 Catalina or newer, install Python3 from this [link](https://www.python.org/downloads/)
 
-### Step by step Guide
+#### Start a Node
 
 1. **Important:** launch `Docker` from your Applications folder. You don't need a Docker Hub account to run nearup
 
 2. Download nearup via `curl`
-	```
-	curl --proto '=https' --tlsv1.2 -sSfL https://up.near.dev | python3
-	```
-	The output shoud be `Nearup is installed to ~/.nearup!`. 
-	Otherwise, you may receive an alert to install Xcode Command Line Tools. Follow the steps. Once completed, try again to copy and paste the command above.
+
+    ```
+    curl --proto '=https' --tlsv1.2 -sSfL https://up.near.dev | python3
+    ```
+
+    The output shoud be `Nearup is installed to ~/.nearup!`. 
+    Otherwise, you may receive an alert to install Xcode Command Line Tools. Follow the steps. Once completed, try again to copy and paste the command above.
 
 3. Restart the terminal, or issue the command 
-	```
-	source ~/.profile
-	```
-	No output is expected.
+
+    ```
+    source ~/.profile
+    ```
+
+    No output is expected.
 
 4. Launch the nearup with the command
-	```
-	nearup betanet --verbose
-	```
-	The output will look like this:
-	```
-	Pull docker image nearprotocol/nearcore:beta
-	Setting up network configuration.
-	Enter your account ID (leave empty if not going to be a validator): lakecat
-	Generating node key...
-	Node key generated
-	Generating validator key...
-	Validator key generated
-	Stake for user 'lakecat' with 'ed25519:HigQXU4QkAvfsuMPTyL5f65coWnCAkR4Yi7RiJPcQKNv'
-	Starting NEAR client docker...
-	Node is running! 
-	To check logs call: docker logs --follow nearcore
-	```
-	Nearup will ask your `account ID`, for now you can leave it empty. If you already have a wallet on https://wallet.betanet.nearprotocol.com, feel free to use your `account ID` for future use as a validator.
+
+    ```
+    nearup betanet --verbose
+    ```
+
+    The output will look like this:
+
+    ```
+    Pull docker image nearprotocol/nearcore:beta
+    Setting up network configuration.
+    Enter your account ID (leave empty if not going to be a validator): lakecat
+    Generating node key...
+    Node key generated
+    Generating validator key...
+    Validator key generated
+    Stake for user 'lakecat' with 'ed25519:HigQXU4QkAvfsuMPTyL5f65coWnCAkR4Yi7RiJPcQKNv'
+    Starting NEAR client docker...
+    Node is running!
+    To check logs call: docker logs --follow nearcore
+    ```
+
+    Nearup will ask your `account ID`, for now you can leave it empty. If you already have a wallet on https://wallet.betanet.nearprotocol.com, feel free to use your `account ID` for future use as a validator.
 
 5. Check if your node is running correctly by issuing the command
-	```
-	docker logs --follow nearcore
-	```
-	The output will look like this:
-	```
-	Telemetry: https://explorer.nearprotocol.com/api/nodes
-	Bootnodes: 
-	Mar 25 01:38:59.607  INFO near: Did not find "/srv/near/data" path, will be creating new store database    
-	Mar 25 01:39:00.161  INFO stats: Server listening at ed25519:AWDhVpfVDvV85tem2ZUa6CmZQwmPawFuzR1wnoiLirRa@0.0.0.0:24567
-	Mar 25 01:39:10.598  INFO stats: #       0 Downloading headers 0% -/4  5/5/40 peers ⬇ 57.9kiB/s ⬆ 0.8kiB/s 0.00 bps 0 gas/s CPU: 42%, Mem: 39.2 MiB    
-	Mar 25 01:39:20.798  INFO stats: #       0 Downloading headers 2% -/4  5/5/40 peers ⬇ 144.0kiB/s ⬆ 0.9kiB/s 0.00 bps 0 gas/s CPU: 49%, Mem: 50.5 MiB    
-	Mar 25 01:39:30.800  INFO stats: #       0 Downloading headers 3% -/4  5/5/40 peers ⬇ 239.9kiB/s ⬆ 0.9kiB/s 0.00 bps 0 gas/s CPU: 46%, Mem: 58.8 MiB    
-	Mar 25 01:39:40.804  INFO stats: #       0 Downloading headers 4% -/4  5/5/40 peers ⬇ 335.6kiB/s ⬆ 1.0kiB/s 0.00 bps 0 gas/s CPU: 56%, Mem: 68.1 MiB    
-	Mar 25 01:39:50.807  INFO stats: #       0 Downloading headers 5% -/4  5/5/40 peers ⬇ 421.9kiB/s ⬆ 1.1kiB/s 0.00 bps 0 gas/s CPU: 47%, Mem: 75.3 MiB    
-	Mar 25 01:40:00.810  INFO stats: #       0 Downloading headers 6% -/4  5/5/40 peers ⬇ 508.3kiB/s ⬆ 1.2kiB/s 0.00 bps 0 gas/s CPU: 48%, Mem: 81.7 MiB    
-	Mar 25 01:40:10.810  INFO stats: #       0 Downloading headers 7% -/4  5/5/40 peers ⬇ 479.8kiB/s ⬆ 0.8kiB/s 0.00 bps 0 gas/s CPU: 33%, Mem: 86.4 MiB    
-	Mar 25 01:40:20.814  INFO stats: #       0 Downloading headers 7% -/4  5/5/40 peers ⬇ 442.0kiB/s ⬆ 0.4kiB/s 0.00 bps 0 gas/s CPU: 33%, Mem: 91.0 MiB    
-	Mar 25 01:40:31.570  INFO stats: #       0 Downloading headers 8% -/4  5/5/40 peers ⬇ 394.8kiB/s ⬆ 0.4kiB/s 0.00 bps 0 gas/s CPU: 38%, Mem: 96.4 MiB    
-	Mar 25 01:40:42.122  INFO stats: #       0 Downloading headers 9% -/4  5/5/40 peers ⬇ 348.0kiB/s ⬆ 0.4kiB/s 0.00 bps 0 gas/s CPU: 41%, Mem: 101.8 MiB    
-	Mar 25 01:40:52.124  INFO stats: #       0 Downloading headers 9% -/4  5/5/40 peers ⬇ 329.1kiB/s ⬆ 0.4kiB/s 0.00 bps 0 gas/s CPU: 49%, Mem: 107.5 MiB    
-	Mar 25 01:41:03.005  INFO stats: #       0 Downloading headers 10% -/4  5/5/40 peers ⬇ 319.7kiB/s ⬆ 0.3kiB/s 0.00 bps 0 gas/s CPU: 52%, Mem: 113.7 MiB    
-	Mar 25 01:41:13.008  INFO stats: #       0 Downloading headers 11% -/4  5/5/40 peers ⬇ 348.1kiB/s ⬆ 0.3kiB/s 0.00 bps 0 gas/s CPU: 59%, Mem: 120.1 MiB    
-	Mar 25 01:41:23.013  INFO stats: #       0 Downloading headers 12% -/4  5/5/40 peers ⬇ 358.0kiB/s ⬆ 0.4kiB/s 0.00 bps 0 gas/s CPU: 51%, Mem: 125.8 MiB
-	```
 
-### Cleaning up
+    ```
+    docker logs --follow nearcore
+    ```
+
+    The output will look like this:
+
+    ```
+    Telemetry: https://explorer.nearprotocol.com/api/nodes
+    Bootnodes: 
+    Mar 25 01:38:59.607  INFO near: Did not find "/srv/near/data" path, will be creating new store database
+    Mar 25 01:39:00.161  INFO stats: Server listening at ed25519:AWDhVpfVDvV85tem2ZUa6CmZQwmPawFuzR1wnoiLirRa@0.0.0.0:24567
+    Mar 25 01:39:10.598  INFO stats: #       0 Downloading headers 0% -/4  5/5/40 peers ⬇ 57.9kiB/s ⬆ 0.8kiB/s 0.00 bps 0 gas/s CPU: 42%, Mem: 39.2 MiB
+    Mar 25 01:39:20.798  INFO stats: #       0 Downloading headers 2% -/4  5/5/40 peers ⬇ 144.0kiB/s ⬆ 0.9kiB/s 0.00 bps 0 gas/s CPU: 49%, Mem: 50.5 MiB
+    Mar 25 01:39:30.800  INFO stats: #       0 Downloading headers 3% -/4  5/5/40 peers ⬇ 239.9kiB/s ⬆ 0.9kiB/s 0.00 bps 0 gas/s CPU: 46%, Mem: 58.8 MiB
+    Mar 25 01:39:40.804  INFO stats: #       0 Downloading headers 4% -/4  5/5/40 peers ⬇ 335.6kiB/s ⬆ 1.0kiB/s 0.00 bps 0 gas/s CPU: 56%, Mem: 68.1 MiB
+    Mar 25 01:39:50.807  INFO stats: #       0 Downloading headers 5% -/4  5/5/40 peers ⬇ 421.9kiB/s ⬆ 1.1kiB/s 0.00 bps 0 gas/s CPU: 47%, Mem: 75.3 MiB
+    Mar 25 01:40:00.810  INFO stats: #       0 Downloading headers 6% -/4  5/5/40 peers ⬇ 508.3kiB/s ⬆ 1.2kiB/s 0.00 bps 0 gas/s CPU: 48%, Mem: 81.7 MiB
+    Mar 25 01:40:10.810  INFO stats: #       0 Downloading headers 7% -/4  5/5/40 peers ⬇ 479.8kiB/s ⬆ 0.8kiB/s 0.00 bps 0 gas/s CPU: 33%, Mem: 86.4 MiB
+    Mar 25 01:40:20.814  INFO stats: #       0 Downloading headers 7% -/4  5/5/40 peers ⬇ 442.0kiB/s ⬆ 0.4kiB/s 0.00 bps 0 gas/s CPU: 33%, Mem: 91.0 MiB
+    Mar 25 01:40:31.570  INFO stats: #       0 Downloading headers 8% -/4  5/5/40 peers ⬇ 394.8kiB/s ⬆ 0.4kiB/s 0.00 bps 0 gas/s CPU: 38%, Mem: 96.4 MiB
+    Mar 25 01:40:42.122  INFO stats: #       0 Downloading headers 9% -/4  5/5/40 peers ⬇ 348.0kiB/s ⬆ 0.4kiB/s 0.00 bps 0 gas/s CPU: 41%, Mem: 101.8 MiB
+    Mar 25 01:40:52.124  INFO stats: #       0 Downloading headers 9% -/4  5/5/40 peers ⬇ 329.1kiB/s ⬆ 0.4kiB/s 0.00 bps 0 gas/s CPU: 49%, Mem: 107.5 MiB
+    Mar 25 01:41:03.005  INFO stats: #       0 Downloading headers 10% -/4  5/5/40 peers ⬇ 319.7kiB/s ⬆ 0.3kiB/s 0.00 bps 0 gas/s CPU: 52%, Mem: 113.7 MiB
+    Mar 25 01:41:13.008  INFO stats: #       0 Downloading headers 11% -/4  5/5/40 peers ⬇ 348.1kiB/s ⬆ 0.3kiB/s 0.00 bps 0 gas/s CPU: 59%, Mem: 120.1 MiB
+    Mar 25 01:41:23.013  INFO stats: #       0 Downloading headers 12% -/4  5/5/40 peers ⬇ 358.0kiB/s ⬆ 0.4kiB/s 0.00 bps 0 gas/s CPU: 51%, Mem: 125.8 MiB
+    ```
+
+#### Cleaning up
+
 This is the step-by-step guide to remove nearup from your macOS system:
 
-1. Stop nearup
-	```
-	nearup stop
-	```
-	The output will be `Stopping docker near`
-2. Prune Docker 
-	**warning:** you may want to skip this step if you have other containers on your system
-	```
-	docker system prune --volumes
-	```
-	The output will require your confirmation
-	```
-	WARNING! This will remove:
-	  - all stopped containers
-	  - all networks not used by at least one container
-	  - all volumes not used by at least one container
-	  - all dangling images
-	  - all dangling build cache
-	Are you sure you want to continue? [y/N]
-	```
+1. Stop a running node
+
+    ```
+    nearup stop
+    ```
+
+    The output will be `Stopping docker near`
+2. Prune Docker
+
+    **warning:** you may want to skip this step if you have other containers on your system
+    
+    ```
+    docker system prune --volumes
+    ```
+
+    The output will require your confirmation
+
+    ```
+    WARNING! This will remove:
+    - all stopped containers
+    - all networks not used by at least one container
+    - all volumes not used by at least one container
+    - all dangling images
+    - all dangling build cache
+    Are you sure you want to continue? [y/N]
+    ```
 3. Open your `$HOME` directory
-	```
-	cd $home
-	```
-4. Remove .near folder with the command
-	```
-	rm -ri .near
-	```
-	The output will require your confirmation to delete every file and folder
-	```
-	Nearkats-MacBook-Pro:.nearup nearkat$ rm -ri $HOME/.near
-	examine files in directory /Users/nearkat/.near? yes
-	remove /Users/nearkat/.near/genesis.json? yes
-	remove /Users/nearkat/.near/config.json? yes
-	remove /Users/nearkat/.near/node_key.json? yes
-	examine files in directory /Users/nearkat/.near/data? yes
-	remove /Users/nearkat/.near/data/IDENTITY? y
-	remove /Users/nearkat/.near/data/000003.log? y
-	remove /Users/nearkat/.near/data/LOCK? y
-	remove /Users/nearkat/.near/data/OPTIONS-000078? y
-	remove /Users/nearkat/.near/data/CURRENT? y
-	remove /Users/nearkat/.near/data/LOG? y
-	remove /Users/nearkat/.near/data/MANIFEST-000004? y
-	remove /Users/nearkat/.near/data/OPTIONS-000080? y
-	remove /Users/nearkat/.near/data? y
-	remove /Users/nearkat/.near/validator_key.json? y
-	remove /Users/nearkat/.near? y
-	```
-	You may save the LOG directory for future use. Alternatively, you can use `rm -rf .near` to skip any confirmation.
+
+    ```
+    cd $HOME
+    ```
+4. Remove `.near` folder with the command
+
+    ```
+    rm -ri .near
+    ```
+
+    The output will require your confirmation to delete every file and folder
+
+    ```
+    Nearkats-MacBook-Pro:.nearup nearkat$ rm -ri $HOME/.near
+    examine files in directory /Users/nearkat/.near? yes
+    remove /Users/nearkat/.near/genesis.json? yes
+    remove /Users/nearkat/.near/config.json? yes
+    remove /Users/nearkat/.near/node_key.json? yes
+    examine files in directory /Users/nearkat/.near/data? yes
+    remove /Users/nearkat/.near/data/IDENTITY? y
+    remove /Users/nearkat/.near/data/000003.log? y
+    remove /Users/nearkat/.near/data/LOCK? y
+    remove /Users/nearkat/.near/data/OPTIONS-000078? y
+    remove /Users/nearkat/.near/data/CURRENT? y
+    remove /Users/nearkat/.near/data/LOG? y
+    remove /Users/nearkat/.near/data/MANIFEST-000004? y
+    remove /Users/nearkat/.near/data/OPTIONS-000080? y
+    remove /Users/nearkat/.near/data? y
+    remove /Users/nearkat/.near/validator_key.json? y
+    remove /Users/nearkat/.near? y
+    ```
+
+    You may save the LOG directory for future use. Alternatively, you can use `rm -rf .near` to skip any confirmation.
 5. Uninstall `Docker`, by moving it from applications folder to the trash
-
-

--- a/README.md
+++ b/README.md
@@ -6,32 +6,33 @@ Public scripts to launch near devnet, betanet and testnet node
 ```
 curl --proto '=https' --tlsv1.2 -sSfL https://up.near.dev | python3
 ```
-Nearup automatically add itself to PATH. And on each run, it self updates to latest version.
+Nearup automatically add itself to PATH: restart the terminal, or issue the command `source ~/.profile`.
+On each run, nearup self-updates to the latest version.
 
 ## Start devnet, betanet, testnet
 ```
-./nearup devnet
-./nearup betanet
-./nearup testnet
+nearup devnet
+nearup betanet
+nearup testnet
 ```
-Where `devnet` is the nightly release; `betanet` is the weekly release; `testnet` the stable release with monthly releases.
+Where `devnet` is the nightly release; `betanet` is the weekly release; `testnet` is the stable release.
 
 ## Start devnet, betanet, testnet with officially compiled binary
 Currently Linux only:
 ```
-./nearup betanet --nodocker
+nearup betanet --nodocker
 ```
-Replace `betanet` with the network you want to use
+Replace `betanet` with `devnet` or `testnet` if you want to use a different network
 
 ## Start devnet, betanet, testnet with local nearcore
 ```
 # compile in nearcore/ with `make release` or `make debug` first
-./nearup {devnet, betanet, testnet} --nodocker --binary-path path/to/nearcore/target/{debug, release}
+nearup {devnet, betanet, testnet} --nodocker --binary-path path/to/nearcore/target/{debug, release}
 ```
 
 ## Stop a running node
 ```
-./nearup stop
+nearup stop
 ```
 
 ## Additional options
@@ -59,7 +60,7 @@ Nearup runs also on Apple macOS. Requirements:
 
 3. Restart the terminal, or issue the command `source ~/.profile`
 
-4. Launch the nearup with the command `./nearup betanet --verbose`:
+4. Launch the nearup with the command `nearup betanet --verbose`:
 	```
 	Nearkats-MacBook-Pro:.nearup nearkat$ ./nearup betanet --verbose
 	Pull docker image nearprotocol/nearcore:beta
@@ -102,13 +103,13 @@ Nearup runs also on Apple macOS. Requirements:
 ### Cleaning up:
 In order to remove NEAR Betanet node and reclaim disk space, you have to:
 
-1. Stop nearup `./nearup stop`:
+1. Stop nearup `nearup stop`:
 	```
 	Nearkats-MacBook-Pro:.nearup nearkat$ ./nearup stop
 	Stopping docker near
 	```
 2. Be sure to open the correct directory: `cd $HOME`
-3. Reclaim disk space by removing .near folder, by typing the command `rm -ri .near`. Press `yes` or `y` to confirm that you want to delete the files:
+3. Reclaim disk space by removing .near folder with the command `rm -ri .near`:
 	```
 	Nearkats-MacBook-Pro:.nearup nearkat$ rm -ri $HOME/.near
 	examine files in directory /Users/nearkat/.near? yes

--- a/README.md
+++ b/README.md
@@ -39,35 +39,104 @@ nearup {devnet, betanet, testnet} --help
 
 ## OSx Instructions to test NEAR Betanet on your Macbook Pro
 Nearup runs also on Apple OSx. Requirements:
-- At least 40GB of HDD space available
-- [Python3](https://www.python.org/downloads/)
-- [Docker for Mac](https://hub.docker.com/editions/community/docker-ce-desktop-mac/)
-- Xcode (installation starts automatically)
+	- At least 40GB of HDD space available
+	- [Install Python3 by clicking here](https://www.python.org/downloads/)
+	- [Install Docker for Mac by clicking here](https://hub.docker.com/editions/community/docker-ce-desktop-mac/)
+	- Xcode (installation starts automatically)
 
-1. Install the latest version of Python3 and Docker, by opening the links in the requirements
-2. Open a terminal window (press `CMD` anb `spacebar` buttons together)
-3. Type `terminal` and press `enter`. You should see a new window with the following text:
+1. Be sure that you installed the latest version of Python3 and Docker, by opening the links in the requirements above
+2.  **Important:** first launch `Docker` from your Applications folder, or your Launchpad. No worries: you won't require a Docker Hub account to use it, so feel free to skip the login part (we simply need Docker installed on your laptop)
+3. Open Spotlight by pressing `Command` and `spacebar` buttons together
+4. Type `terminal` and press `enter`. You should see a new window with the following text:
 	```
 	Last login: Tue Mar 24 18:06:46 2020
 	Nearkats-MacBook-Pro:~ nearkat$ 
 	```
-4. In the Terminal screen, type
-```
-curl --proto '=https' --tlsv1.2 -sSfL https://up.near.dev | python3
-```
-If you haven't yet, you will receive an alert to install Xcode. Once completed, try again to execute the command above.
-5. Open the Nearup folder:
-```
-cd $HOME/.nearup
-```
-6. Start the node by typing the command:
-```
-nearup betanet --verbose
-```
-7. Nearup will ask your `account id`, you can keep it empty by now
-8. Check how's your node is doing:
-```
-docker logs --follow nearcore
-```
+	Alternatively, you can ask Siri `open terminal`, it works too!
+5. In the Terminal screen, type `curl --proto '=https' --tlsv1.2 -sSfL https://up.near.dev | python3`:
+	```
+	Nearup is installed to ~/.nearup!
+	```
+	You may receive an alert to install Xcode. Follow the steps. Once completed, try again to copy and paste the command above.
+6. Open the Nearup folder: `cd $HOME/.nearup`:
+	```
+	Nearkats-MacBook-Pro:.nearup nearkat$ 
+	```
+7. Start the node by typing the command `./nearup betanet --verbose`:
+	```
+	Nearkats-MacBook-Pro:.nearup nearkat$ ./nearup betanet --verbose
+	Pull docker image nearprotocol/nearcore:beta
+	Setting up network configuration.
+	Enter your account ID (leave empty if not going to be a validator): lakecat
+	Generating node key...
+	Node key generated
+	Generating validator key...
+	Validator key generated
+	Stake for user 'lakecat' with 'ed25519:HigQXU4QkAvfsuMPTyL5f65coWnCAkR4Yi7RiJPcQKNv'
+	Starting NEAR client docker...
+	Node is running! 
+	To check logs call: docker logs --follow nearcore
+	```
+	Nearup will ask your `account ID`, but you can leave it empty by now. If you have already a wallet on https://wallet.betanet.nearprotocol.com, feel free to use your existing account ID - for future use as a validator.
+9. Check how's your node is doing: `docker logs --follow nearcore`
+	```
+	Nearkats-MacBook-Pro:.nearup nearkat$ docker logs --follow nearcore
+	Telemetry: https://explorer.nearprotocol.com/api/nodes
+	Bootnodes: 
+	Mar 25 01:38:59.607  INFO near: Did not find "/srv/near/data" path, will be creating new store database    
+	Mar 25 01:39:00.161  INFO stats: Server listening at ed25519:AWDhVpfVDvV85tem2ZUa6CmZQwmPawFuzR1wnoiLirRa@0.0.0.0:24567
+	Mar 25 01:39:10.598  INFO stats: #       0 Downloading headers 0% -/4  5/5/40 peers ⬇ 57.9kiB/s ⬆ 0.8kiB/s 0.00 bps 0 gas/s CPU: 42%, Mem: 39.2 MiB    
+	Mar 25 01:39:20.798  INFO stats: #       0 Downloading headers 2% -/4  5/5/40 peers ⬇ 144.0kiB/s ⬆ 0.9kiB/s 0.00 bps 0 gas/s CPU: 49%, Mem: 50.5 MiB    
+	Mar 25 01:39:30.800  INFO stats: #       0 Downloading headers 3% -/4  5/5/40 peers ⬇ 239.9kiB/s ⬆ 0.9kiB/s 0.00 bps 0 gas/s CPU: 46%, Mem: 58.8 MiB    
+	Mar 25 01:39:40.804  INFO stats: #       0 Downloading headers 4% -/4  5/5/40 peers ⬇ 335.6kiB/s ⬆ 1.0kiB/s 0.00 bps 0 gas/s CPU: 56%, Mem: 68.1 MiB    
+	Mar 25 01:39:50.807  INFO stats: #       0 Downloading headers 5% -/4  5/5/40 peers ⬇ 421.9kiB/s ⬆ 1.1kiB/s 0.00 bps 0 gas/s CPU: 47%, Mem: 75.3 MiB    
+	Mar 25 01:40:00.810  INFO stats: #       0 Downloading headers 6% -/4  5/5/40 peers ⬇ 508.3kiB/s ⬆ 1.2kiB/s 0.00 bps 0 gas/s CPU: 48%, Mem: 81.7 MiB    
+	Mar 25 01:40:10.810  INFO stats: #       0 Downloading headers 7% -/4  5/5/40 peers ⬇ 479.8kiB/s ⬆ 0.8kiB/s 0.00 bps 0 gas/s CPU: 33%, Mem: 86.4 MiB    
+	Mar 25 01:40:20.814  INFO stats: #       0 Downloading headers 7% -/4  5/5/40 peers ⬇ 442.0kiB/s ⬆ 0.4kiB/s 0.00 bps 0 gas/s CPU: 33%, Mem: 91.0 MiB    
+	Mar 25 01:40:31.570  INFO stats: #       0 Downloading headers 8% -/4  5/5/40 peers ⬇ 394.8kiB/s ⬆ 0.4kiB/s 0.00 bps 0 gas/s CPU: 38%, Mem: 96.4 MiB    
+	Mar 25 01:40:42.122  INFO stats: #       0 Downloading headers 9% -/4  5/5/40 peers ⬇ 348.0kiB/s ⬆ 0.4kiB/s 0.00 bps 0 gas/s CPU: 41%, Mem: 101.8 MiB    
+	Mar 25 01:40:52.124  INFO stats: #       0 Downloading headers 9% -/4  5/5/40 peers ⬇ 329.1kiB/s ⬆ 0.4kiB/s 0.00 bps 0 gas/s CPU: 49%, Mem: 107.5 MiB    
+	Mar 25 01:41:03.005  INFO stats: #       0 Downloading headers 10% -/4  5/5/40 peers ⬇ 319.7kiB/s ⬆ 0.3kiB/s 0.00 bps 0 gas/s CPU: 52%, Mem: 113.7 MiB    
+	Mar 25 01:41:13.008  INFO stats: #       0 Downloading headers 11% -/4  5/5/40 peers ⬇ 348.1kiB/s ⬆ 0.3kiB/s 0.00 bps 0 gas/s CPU: 59%, Mem: 120.1 MiB    
+	Mar 25 01:41:23.013  INFO stats: #       0 Downloading headers 12% -/4  5/5/40 peers ⬇ 358.0kiB/s ⬆ 0.4kiB/s 0.00 bps 0 gas/s CPU: 51%, Mem: 125.8 MiB
+	```
+	If you want to exit, just press `control` and `c` together, and close your terminal window
+
+## Cleaning up
+In order to remove NEAR Betanet node and reclaim disk space, you have to:
+
+1. Open again a `terminal` window (ask again to Siri, or use Spotlight)
+2. Type again the command:
+	```
+	cd $HOME/.nearup
+	```
+3. Stop nearup `./nearup stop`:
+	```
+	Nearkats-MacBook-Pro:.nearup nearkat$ ./nearup stop
+	Stopping docker near
+	```
+4. Open the folder `cd $HOME`
+5. Reclaim disk space by removing .near folder, issuing the command `rm -ri .near`. Press `yes` or `y` to confirm that you want to delete the files:
+	```
+	Nearkats-MacBook-Pro:.nearup nearkat$ rm -ri $HOME/.near
+	examine files in directory /Users/nearkat/.near? yes
+	remove /Users/nearkat/.near/genesis.json? yes
+	remove /Users/nearkat/.near/config.json? yes
+	remove /Users/nearkat/.near/node_key.json? yes
+	examine files in directory /Users/nearkat/.near/data? yes
+	remove /Users/nearkat/.near/data/IDENTITY? y
+	remove /Users/nearkat/.near/data/000003.log? y
+	remove /Users/nearkat/.near/data/LOCK? y
+	remove /Users/nearkat/.near/data/OPTIONS-000078? y
+	remove /Users/nearkat/.near/data/CURRENT? y
+	remove /Users/nearkat/.near/data/LOG? y
+	remove /Users/nearkat/.near/data/MANIFEST-000004? y
+	remove /Users/nearkat/.near/data/OPTIONS-000080? y
+	remove /Users/nearkat/.near/data? y
+	remove /Users/nearkat/.near/validator_key.json? y
+	remove /Users/nearkat/.near? y
+	```
+	WARNING: `rm` command is an **extremely powerful** and **dangerous** command to delete files, so you don't really want to use it unless you know what you are doing. Please DOUBLE CHECK that you are deleting `.near` folder, and not something else!
+6. Remove `Docker`, by simply moving it to the trash
 
 

--- a/README.md
+++ b/README.md
@@ -10,26 +10,28 @@ Nearup automatically add itself to PATH. And on each run, it self updates to lat
 
 ## Start devnet, betanet, testnet
 ```
-nearup devnet
-nearup betanet
-nearup testnet
+./nearup devnet
+./nearup betanet
+./nearup testnet
 ```
+Where `devnet` is the nightly release; `betanet` is the weekly release; `testnet` the stable release with monthly releases.
 
 ## Start devnet, betanet, testnet with officially compiled binary
 Currently Linux only:
 ```
-nearup {devnet, betanet, testnet} --nodocker
+./nearup betanet --nodocker
 ```
+Replace `betanet` with the network you want to use
 
 ## Start devnet, betanet, testnet with local nearcore
 ```
 # compile in nearcore/ with `make release` or `make debug` first
-nearup {devnet, betanet, testnet} --nodocker --binary-path path/to/nearcore/target/{debug, release}
+./nearup {devnet, betanet, testnet} --nodocker --binary-path path/to/nearcore/target/{debug, release}
 ```
 
 ## Stop a running node
 ```
-nearup stop
+./nearup stop
 ```
 
 ## Additional options
@@ -37,40 +39,27 @@ nearup stop
 nearup {devnet, betanet, testnet} --help
 ```
 
-## OSx Instructions to test NEAR Betanet on your Macbook Pro
-Nearup runs also on Apple OSx. Requirements:
+## macOS Instructions to test NEAR Betanet on your MacBook Pro
+Nearup runs also on Apple macOS. Requirements:
 - At least 40GB of HDD space available
-- [Install Python3 by using this link](https://www.python.org/downloads/)
 - [Install Docker for Mac by using this link](https://hub.docker.com/editions/community/docker-ce-desktop-mac/)
-- Xcode (installation will start automatically during the installation process)
+- Xcode Command Line Tools (installation will start automatically during the process)
+- If you are not using macOS 10.15 Catalina, [install Python3 from this link](https://www.python.org/downloads/)
 
 ### Step by step Guide:
-1. Be sure that you installed the latest version of Python3 and Docker, by opening the links in the requirements above
 
-2. **Important:** first launch `Docker` from your Applications folder, or your Launchpad. No worries: you won't require a Docker Hub account to use it, so feel free to skip the login part (we simply need Docker installed on your laptop)
+1. **Important:** first launch `Docker` from your Applications folder. You don't need a Docker Hub account to run nearup
 
-3. Open Spotlight by pressing `⌘command` and `spacebar` buttons together
-
-4. Type `terminal` and press `enter`. You should see a new window with text similar to this one:
-	```
-	Last login: Tue Mar 24 18:06:46 2020
-	Nearkats-MacBook-Pro:~ nearkat$ 
-	```
-	Alternatively, you can ask Siri `open terminal`, it works too!
-
-5. In the Terminal screen, type `curl --proto '=https' --tlsv1.2 -sSfL https://up.near.dev | python3` (feel free to copy and paste, by using the usual copy&paste `⌘c` and `⌘v`):
+2. Issue the command `curl --proto '=https' --tlsv1.2 -sSfL https://up.near.dev | python3`
 	```
 	Nearkats-MacBook-Pro:~ nearkat$ curl --proto '=https' --tlsv1.2 -sSfL https://up.near.dev | python3
 	Nearup is installed to ~/.nearup!
 	```
-	You may receive an alert to install Xcode. Follow the steps. Once completed, try again to copy and paste the command above.
+	You may receive an alert to install Xcode Command Line Tools. Follow the steps. Once completed, try again to copy and paste the command above.
 
-6. Open the Nearup folder: `cd $HOME/.nearup`:
-	```
-	Nearkats-MacBook-Pro:.nearup nearkat$ 
-	```
+3. Restart the terminal, or issue the command `source ~/.profile`
 
-7. Start the node by typing the command `./nearup betanet --verbose`:
+4. Launch the nearup with the command `./nearup betanet --verbose`:
 	```
 	Nearkats-MacBook-Pro:.nearup nearkat$ ./nearup betanet --verbose
 	Pull docker image nearprotocol/nearcore:beta
@@ -85,9 +74,9 @@ Nearup runs also on Apple OSx. Requirements:
 	Node is running! 
 	To check logs call: docker logs --follow nearcore
 	```
-	Nearup will ask your `account ID`, but you can leave it empty by now. If you have already a wallet on https://wallet.betanet.nearprotocol.com, feel free to use your existing account ID - for future use as a validator.
+	Nearup will ask your `account ID`, you can leave it empty by now. If you have already a wallet on https://wallet.betanet.nearprotocol.com, feel free to use your account ID for future use as a validator.
 
-9. Check if your node is running correctly: `docker logs --follow nearcore`
+5. Check if your node is running correctly: `docker logs --follow nearcore`
 	```
 	Nearkats-MacBook-Pro:.nearup nearkat$ docker logs --follow nearcore
 	Telemetry: https://explorer.nearprotocol.com/api/nodes
@@ -109,23 +98,17 @@ Nearup runs also on Apple OSx. Requirements:
 	Mar 25 01:41:13.008  INFO stats: #       0 Downloading headers 11% -/4  5/5/40 peers ⬇ 348.1kiB/s ⬆ 0.3kiB/s 0.00 bps 0 gas/s CPU: 59%, Mem: 120.1 MiB    
 	Mar 25 01:41:23.013  INFO stats: #       0 Downloading headers 12% -/4  5/5/40 peers ⬇ 358.0kiB/s ⬆ 0.4kiB/s 0.00 bps 0 gas/s CPU: 51%, Mem: 125.8 MiB
 	```
-	If you want to exit, just press `⌃control` and `c` together, and close your terminal window
 
 ### Cleaning up:
 In order to remove NEAR Betanet node and reclaim disk space, you have to:
 
-1. Open again a `terminal` window (ask again to Siri, or use Spotlight)
-2. Type again the command:
-	```
-	cd $HOME/.nearup
-	```
-3. Stop nearup `./nearup stop`:
+1. Stop nearup `./nearup stop`:
 	```
 	Nearkats-MacBook-Pro:.nearup nearkat$ ./nearup stop
 	Stopping docker near
 	```
-4. Open the folder `cd $HOME`
-5. Reclaim disk space by removing .near folder, by typing the command `rm -ri .near`. Press `yes` or `y` to confirm that you want to delete the files:
+2. Be sure to open the correct directory: `cd $HOME`
+3. Reclaim disk space by removing .near folder, by typing the command `rm -ri .near`. Press `yes` or `y` to confirm that you want to delete the files:
 	```
 	Nearkats-MacBook-Pro:.nearup nearkat$ rm -ri $HOME/.near
 	examine files in directory /Users/nearkat/.near? yes
@@ -145,7 +128,7 @@ In order to remove NEAR Betanet node and reclaim disk space, you have to:
 	remove /Users/nearkat/.near/validator_key.json? y
 	remove /Users/nearkat/.near? y
 	```
-	WARNING: `rm` command is an **extremely powerful** and **dangerous** command to delete files, so you don't really want to use it unless you know what you are doing. Please DOUBLE CHECK that you are deleting `.near` folder, and not something else!
-6. Remove `Docker`, by simply moving it from your applications folder to the trash
+	You may save the LOG directory for future use. As a faster alternative, you can use `rm -rf .near`
+4. Remove `Docker`, by simply moving it from your applications folder to the trash
 
 

--- a/README.md
+++ b/README.md
@@ -39,10 +39,10 @@ nearup {devnet, betanet, testnet} --help
 
 ## OSx Instructions to test NEAR Betanet on your Macbook Pro
 Nearup runs also on Apple OSx. Requirements:
-	- At least 40GB of HDD space available
-	- [Install Python3 by clicking here](https://www.python.org/downloads/)
-	- [Install Docker for Mac by clicking here](https://hub.docker.com/editions/community/docker-ce-desktop-mac/)
-	- Xcode (installation starts automatically)
+- At least 40GB of HDD space available
+- [Install Python3 by clicking here](https://www.python.org/downloads/){:target="_blank"}
+- [Install Docker for Mac by clicking here](https://hub.docker.com/editions/community/docker-ce-desktop-mac/){:target="_blank"}
+- Xcode (installation will start automatically when you issue the `curl` command below)
 
 1. Be sure that you installed the latest version of Python3 and Docker, by opening the links in the requirements above
 2.  **Important:** first launch `Docker` from your Applications folder, or your Launchpad. No worries: you won't require a Docker Hub account to use it, so feel free to skip the login part (we simply need Docker installed on your laptop)

--- a/README.md
+++ b/README.md
@@ -36,3 +36,38 @@ nearup stop
 ```
 nearup {devnet, betanet, testnet} --help
 ```
+
+## OSx Instructions to test NEAR Betanet on your Macbook Pro
+Nearup runs also on Apple OSx. Requirements:
+- At least 40GB of HDD space available
+- [Python3](https://www.python.org/downloads/)
+- [Docker for Mac](https://hub.docker.com/editions/community/docker-ce-desktop-mac/)
+- Xcode (installation starts automatically)
+
+1. Install the latest version of Python3 and Docker, by opening the links in the requirements
+2. Open a terminal window (press `CMD` anb `spacebar` buttons together)
+3. Type `terminal` and press `enter`. You should see a new window with the following text:
+	```
+	Last login: Tue Mar 24 18:06:46 2020
+	Nearkats-MacBook-Pro:~ nearkat$ 
+	```
+4. In the Terminal screen, type
+```
+curl --proto '=https' --tlsv1.2 -sSfL https://up.near.dev | python3
+```
+If you haven't yet, you will receive an alert to install Xcode. Once completed, try again to execute the command above.
+5. Open the Nearup folder:
+```
+cd $HOME/.nearup
+```
+6. Start the node by typing the command:
+```
+nearup betanet --verbose
+```
+7. Nearup will ask your `account id`, you can keep it empty by now
+8. Check how's your node is doing:
+```
+docker logs --follow nearcore
+```
+
+

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Public scripts to launch near devnet, betanet and testnet node
 ```
 curl --proto '=https' --tlsv1.2 -sSfL https://up.near.dev | python3
 ```
-Nearup automatically add itself to PATH: restart the terminal, or issue the command `source ~/.profile`.
+Nearup automatically adds itself to PATH: restart the terminal, or issue the command `source ~/.profile`.
 On each run, nearup self-updates to the latest version.
 
 ## Start devnet, betanet, testnet
@@ -25,8 +25,8 @@ nearup betanet --nodocker
 Replace `betanet` with `devnet` or `testnet` if you want to use a different network
 
 ## Start devnet, betanet, testnet with local nearcore
+Compile in nearcore/ with `make release` or `make debug` first
 ```
-# compile in nearcore/ with `make release` or `make debug` first
 nearup {devnet, betanet, testnet} --nodocker --binary-path path/to/nearcore/target/{debug, release}
 ```
 
@@ -40,29 +40,36 @@ nearup stop
 nearup {devnet, betanet, testnet} --help
 ```
 
-## macOS Instructions to test NEAR Betanet on your MacBook Pro
-Nearup runs also on Apple macOS. Requirements:
-- At least 40GB of HDD space available
+## Run NEAR betanet on macOS
+nearup runs also on Apple macOS. Requirements:
+- At least 40GB of storage space available
 - [Install Docker for Mac by using this link](https://hub.docker.com/editions/community/docker-ce-desktop-mac/)
 - Xcode Command Line Tools (installation will start automatically during the process)
 - If you are not using macOS 10.15 Catalina, [install Python3 from this link](https://www.python.org/downloads/)
 
-### Step by step Guide:
+### Step by step Guide
 
-1. **Important:** first launch `Docker` from your Applications folder. You don't need a Docker Hub account to run nearup
+1. **Important:** launch `Docker` from your Applications folder. You don't need a Docker Hub account to run nearup
 
-2. Issue the command `curl --proto '=https' --tlsv1.2 -sSfL https://up.near.dev | python3`
+2. Download nearup via `curl`
 	```
-	Nearkats-MacBook-Pro:~ nearkat$ curl --proto '=https' --tlsv1.2 -sSfL https://up.near.dev | python3
-	Nearup is installed to ~/.nearup!
+	curl --proto '=https' --tlsv1.2 -sSfL https://up.near.dev | python3
 	```
-	You may receive an alert to install Xcode Command Line Tools. Follow the steps. Once completed, try again to copy and paste the command above.
+	The output shoud be `Nearup is installed to ~/.nearup!`. 
+	Otherwise, you may receive an alert to install Xcode Command Line Tools. Follow the steps. Once completed, try again to copy and paste the command above.
 
-3. Restart the terminal, or issue the command `source ~/.profile`
-
-4. Launch the nearup with the command `nearup betanet --verbose`:
+3. Restart the terminal, or issue the command 
 	```
-	Nearkats-MacBook-Pro:.nearup nearkat$ ./nearup betanet --verbose
+	source ~/.profile
+	```
+	No output is expected.
+
+4. Launch the nearup with the command
+	```
+	nearup betanet --verbose
+	```
+	The output will look like this:
+	```
 	Pull docker image nearprotocol/nearcore:beta
 	Setting up network configuration.
 	Enter your account ID (leave empty if not going to be a validator): lakecat
@@ -75,11 +82,14 @@ Nearup runs also on Apple macOS. Requirements:
 	Node is running! 
 	To check logs call: docker logs --follow nearcore
 	```
-	Nearup will ask your `account ID`, you can leave it empty by now. If you have already a wallet on https://wallet.betanet.nearprotocol.com, feel free to use your account ID for future use as a validator.
+	Nearup will ask your `account ID`, for now you can leave it empty. If you already have a wallet on https://wallet.betanet.nearprotocol.com, feel free to use your `account ID` for future use as a validator.
 
-5. Check if your node is running correctly: `docker logs --follow nearcore`
+5. Check if your node is running correctly by issuing the command
 	```
-	Nearkats-MacBook-Pro:.nearup nearkat$ docker logs --follow nearcore
+	docker logs --follow nearcore
+	```
+	The output will look like this:
+	```
 	Telemetry: https://explorer.nearprotocol.com/api/nodes
 	Bootnodes: 
 	Mar 25 01:38:59.607  INFO near: Did not find "/srv/near/data" path, will be creating new store database    
@@ -100,16 +110,38 @@ Nearup runs also on Apple macOS. Requirements:
 	Mar 25 01:41:23.013  INFO stats: #       0 Downloading headers 12% -/4  5/5/40 peers ⬇ 358.0kiB/s ⬆ 0.4kiB/s 0.00 bps 0 gas/s CPU: 51%, Mem: 125.8 MiB
 	```
 
-### Cleaning up:
-In order to remove NEAR Betanet node and reclaim disk space, you have to:
+### Cleaning up
+This is the step-by-step guide to remove nearup from your macOS system:
 
-1. Stop nearup `nearup stop`:
+1. Stop nearup
 	```
-	Nearkats-MacBook-Pro:.nearup nearkat$ ./nearup stop
-	Stopping docker near
+	nearup stop
 	```
-2. Be sure to open the correct directory: `cd $HOME`
-3. Reclaim disk space by removing .near folder with the command `rm -ri .near`:
+	The output will be `Stopping docker near`
+2. Prune Docker 
+	**warning:** you may want to skip this step if you have other containers on your system
+	```
+	docker system prune --volumes
+	```
+	The output will require your confirmation
+	```
+	WARNING! This will remove:
+	  - all stopped containers
+	  - all networks not used by at least one container
+	  - all volumes not used by at least one container
+	  - all dangling images
+	  - all dangling build cache
+	Are you sure you want to continue? [y/N]
+	```
+3. Open your `$HOME` directory
+	```
+	cd $home
+	```
+4. Remove .near folder with the command
+	```
+	rm -ri .near
+	```
+	The output will require your confirmation to delete every file and folder
 	```
 	Nearkats-MacBook-Pro:.nearup nearkat$ rm -ri $HOME/.near
 	examine files in directory /Users/nearkat/.near? yes
@@ -129,7 +161,7 @@ In order to remove NEAR Betanet node and reclaim disk space, you have to:
 	remove /Users/nearkat/.near/validator_key.json? y
 	remove /Users/nearkat/.near? y
 	```
-	You may save the LOG directory for future use. As a faster alternative, you can use `rm -rf .near`
-4. Remove `Docker`, by simply moving it from your applications folder to the trash
+	You may save the LOG directory for future use. Alternatively, you can use `rm -rf .near` to skip any confirmation.
+5. Uninstall `Docker`, by moving it from applications folder to the trash
 
 

--- a/README.md
+++ b/README.md
@@ -40,28 +40,36 @@ nearup {devnet, betanet, testnet} --help
 ## OSx Instructions to test NEAR Betanet on your Macbook Pro
 Nearup runs also on Apple OSx. Requirements:
 - At least 40GB of HDD space available
-- [Install Python3 by clicking here](https://www.python.org/downloads/){:target="_blank"}
-- [Install Docker for Mac by clicking here](https://hub.docker.com/editions/community/docker-ce-desktop-mac/){:target="_blank"}
-- Xcode (installation will start automatically when you issue the `curl` command below)
+- [Install Python3 by using this link](https://www.python.org/downloads/)
+- [Install Docker for Mac by using this link](https://hub.docker.com/editions/community/docker-ce-desktop-mac/)
+- Xcode (installation will start automatically during the installation process)
 
+### Step by step Guide:
 1. Be sure that you installed the latest version of Python3 and Docker, by opening the links in the requirements above
-2.  **Important:** first launch `Docker` from your Applications folder, or your Launchpad. No worries: you won't require a Docker Hub account to use it, so feel free to skip the login part (we simply need Docker installed on your laptop)
-3. Open Spotlight by pressing `Command` and `spacebar` buttons together
-4. Type `terminal` and press `enter`. You should see a new window with the following text:
+
+2. **Important:** first launch `Docker` from your Applications folder, or your Launchpad. No worries: you won't require a Docker Hub account to use it, so feel free to skip the login part (we simply need Docker installed on your laptop)
+
+3. Open Spotlight by pressing `⌘command` and `spacebar` buttons together
+
+4. Type `terminal` and press `enter`. You should see a new window with text similar to this one:
 	```
 	Last login: Tue Mar 24 18:06:46 2020
 	Nearkats-MacBook-Pro:~ nearkat$ 
 	```
 	Alternatively, you can ask Siri `open terminal`, it works too!
-5. In the Terminal screen, type `curl --proto '=https' --tlsv1.2 -sSfL https://up.near.dev | python3`:
+
+5. In the Terminal screen, type `curl --proto '=https' --tlsv1.2 -sSfL https://up.near.dev | python3` (feel free to copy and paste, by using the usual copy&paste `⌘c` and `⌘v`):
 	```
+	Nearkats-MacBook-Pro:~ nearkat$ curl --proto '=https' --tlsv1.2 -sSfL https://up.near.dev | python3
 	Nearup is installed to ~/.nearup!
 	```
 	You may receive an alert to install Xcode. Follow the steps. Once completed, try again to copy and paste the command above.
+
 6. Open the Nearup folder: `cd $HOME/.nearup`:
 	```
 	Nearkats-MacBook-Pro:.nearup nearkat$ 
 	```
+
 7. Start the node by typing the command `./nearup betanet --verbose`:
 	```
 	Nearkats-MacBook-Pro:.nearup nearkat$ ./nearup betanet --verbose
@@ -78,7 +86,8 @@ Nearup runs also on Apple OSx. Requirements:
 	To check logs call: docker logs --follow nearcore
 	```
 	Nearup will ask your `account ID`, but you can leave it empty by now. If you have already a wallet on https://wallet.betanet.nearprotocol.com, feel free to use your existing account ID - for future use as a validator.
-9. Check how's your node is doing: `docker logs --follow nearcore`
+
+9. Check if your node is running correctly: `docker logs --follow nearcore`
 	```
 	Nearkats-MacBook-Pro:.nearup nearkat$ docker logs --follow nearcore
 	Telemetry: https://explorer.nearprotocol.com/api/nodes
@@ -100,9 +109,9 @@ Nearup runs also on Apple OSx. Requirements:
 	Mar 25 01:41:13.008  INFO stats: #       0 Downloading headers 11% -/4  5/5/40 peers ⬇ 348.1kiB/s ⬆ 0.3kiB/s 0.00 bps 0 gas/s CPU: 59%, Mem: 120.1 MiB    
 	Mar 25 01:41:23.013  INFO stats: #       0 Downloading headers 12% -/4  5/5/40 peers ⬇ 358.0kiB/s ⬆ 0.4kiB/s 0.00 bps 0 gas/s CPU: 51%, Mem: 125.8 MiB
 	```
-	If you want to exit, just press `control` and `c` together, and close your terminal window
+	If you want to exit, just press `⌃control` and `c` together, and close your terminal window
 
-## Cleaning up
+### Cleaning up:
 In order to remove NEAR Betanet node and reclaim disk space, you have to:
 
 1. Open again a `terminal` window (ask again to Siri, or use Spotlight)
@@ -116,7 +125,7 @@ In order to remove NEAR Betanet node and reclaim disk space, you have to:
 	Stopping docker near
 	```
 4. Open the folder `cd $HOME`
-5. Reclaim disk space by removing .near folder, issuing the command `rm -ri .near`. Press `yes` or `y` to confirm that you want to delete the files:
+5. Reclaim disk space by removing .near folder, by typing the command `rm -ri .near`. Press `yes` or `y` to confirm that you want to delete the files:
 	```
 	Nearkats-MacBook-Pro:.nearup nearkat$ rm -ri $HOME/.near
 	examine files in directory /Users/nearkat/.near? yes
@@ -137,6 +146,6 @@ In order to remove NEAR Betanet node and reclaim disk space, you have to:
 	remove /Users/nearkat/.near? y
 	```
 	WARNING: `rm` command is an **extremely powerful** and **dangerous** command to delete files, so you don't really want to use it unless you know what you are doing. Please DOUBLE CHECK that you are deleting `.near` folder, and not something else!
-6. Remove `Docker`, by simply moving it to the trash
+6. Remove `Docker`, by simply moving it from your applications folder to the trash
 
 


### PR DESCRIPTION
Added a step-by-step to run nearup on MacOS, to support our internal testing and anyone from the community who wants to run the node locally. 

I tested it on:
- MacBook Pros 2017, 2019 and 2020, with i5 and i7 CPUs, 2 and 4 cores. 16GB of memory, I wasn't able to test it on MacBooks with 8GB (or less) RAM 
- 10.13 High Sierra, 10.14 Mojave and 10.15 Catalina with the latest security patches
- Tests have been done on a clean installation for High Sierra and Catalina, and both clean and "dry-aged" Mojave.

Also, added some minor copy improvements, from @frol suggestions