### PR TITLE
fix verbose and remove confusing telemetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,8 +125,6 @@ nearup runs also on Apple macOS. Requirements:
     The output will look like this:
 
     ```
-    Telemetry: https://explorer.nearprotocol.com/api/nodes
-    Bootnodes: 
     Mar 25 01:38:59.607  INFO near: Did not find "/srv/near/data" path, will be creating new store database
     Mar 25 01:39:00.161  INFO stats: Server listening at ed25519:AWDhVpfVDvV85tem2ZUa6CmZQwmPawFuzR1wnoiLirRa@0.0.0.0:24567
     Mar 25 01:39:10.598  INFO stats: #       0 Downloading headers 0% -/4  5/5/40 peers ⬇ 57.9kiB/s ⬆ 0.8kiB/s 0.00 bps 0 gas/s CPU: 42%, Mem: 39.2 MiB

--- a/main.py
+++ b/main.py
@@ -5,9 +5,6 @@ from nearuplib.nodelib import setup_and_run, stop
 import os
 
 
-TELEMETRY_URL = 'https://explorer.nearprotocol.com/api/nodes'
-
-
 class NearupArgParser(object):
 
     def __init__(self):
@@ -65,7 +62,6 @@ if __name__ == '__main__':
         setup_and_run(nodocker, args.binary_path, args.image, args.home,
                       init_flags=[f'--chain-id={command}'],
                       boot_nodes=args.boot_nodes,
-                      telemetry_url=TELEMETRY_URL,
                       verbose=args.verbose)
     elif command == 'stop':
         stop()

--- a/nearuplib/net_argparser.py
+++ b/nearuplib/net_argparser.py
@@ -3,8 +3,6 @@ import os
 
 
 def create_net_argparser(*, netname, description):
-    TELEMETRY_URL = 'https://explorer.nearprotocol.com/api/nodes'
-
     parser = argparse.ArgumentParser(description=description)
     parser.add_argument('--local', action='store_true',
                         help='deprecated: use --nodocker')

--- a/nearuplib/nodelib.py
+++ b/nearuplib/nodelib.py
@@ -226,30 +226,32 @@ def get_port(home_dir, net):
     return p + ":" + p
 
 
-def run_docker(image, home_dir, boot_nodes, telemetry_url, verbose):
+def run_docker(image, home_dir, boot_nodes, verbose):
     """Runs NEAR core inside the docker container"""
     print("Starting NEAR client docker...")
     docker_stop_if_exists('watchtower')
     docker_stop_if_exists('nearcore')
     # Start nearcore container, mapping home folder and ports.
-    envs = [*(['-e', 'BOOT_NODES=%s' % boot_nodes] if boot_nodes else []),
-            '-e', 'TELEMETRY_URL=%s' % telemetry_url,
-            '-e', 'RUST_BACKTRACE=1']
+    envs = ['-e', 'RUST_BACKTRACE=1']
     rpc_port = get_port(home_dir, 'rpc')
     network_port = get_port(home_dir, 'network')
+    cmd = ['near', '--home', '/srv/near']
     if verbose:
-        envs.extend(['-e', 'VERBOSE=1'])
+        cmd += ['--verbose', '']
+    cmd.append('run')
+    if boot_nodes:
+        cmd.append('--boot-nodes=%s' % boot_nodes)
     subprocess.check_output(['mkdir', '-p', home_dir])
     subprocess.check_output(['docker', 'run', '-u', USER,
                              '-d', '-p', rpc_port, '-p', network_port, '-v', '%s:/srv/near' % home_dir,
                              '-v', '/tmp:/tmp',
                              '--ulimit', 'core=-1',
                              '--name', 'nearcore', '--restart', 'unless-stopped'] +
-                            envs + [image])
+                            envs + [image] + cmd)
     print("Node is running! \nTo check logs call: docker logs --follow nearcore")
 
 
-def run_nodocker(home_dir, binary_path, boot_nodes, telemetry_url, verbose):
+def run_nodocker(home_dir, binary_path, boot_nodes, verbose):
     """Runs NEAR core outside of docker."""
     print("Starting NEAR client...")
     cmd = [f'{binary_path}/near']
@@ -257,7 +259,6 @@ def run_nodocker(home_dir, binary_path, boot_nodes, telemetry_url, verbose):
     if verbose:
         cmd += ['--verbose', '']
     cmd.append('run')
-    cmd.append('--telemetry-url=%s' % telemetry_url)
     if boot_nodes:
         cmd.append('--boot-nodes=%s' % boot_nodes)
     try:
@@ -275,7 +276,7 @@ def check_binary_version(binary_path, chain_id):
             f'Warning: current deployed version on {chain_id} is {latest_deploy_version}, but local binary is {version}. It might not work')
 
 
-def setup_and_run(nodocker, binary_path, image, home_dir, init_flags, boot_nodes, telemetry_url, verbose=False, no_gas_price=False):
+def setup_and_run(nodocker, binary_path, image, home_dir, init_flags, boot_nodes, verbose=False, no_gas_price=False):
     chain_id = get_chain_id_from_flags(init_flags)
     if nodocker:
         if binary_path == '':
@@ -312,9 +313,9 @@ def setup_and_run(nodocker, binary_path, image, home_dir, init_flags, boot_nodes
     print_staking_key(home_dir)
 
     if nodocker:
-        run_nodocker(home_dir, binary_path, boot_nodes, telemetry_url, verbose)
+        run_nodocker(home_dir, binary_path, boot_nodes, verbose)
     else:
-        run_docker(image, home_dir, boot_nodes, telemetry_url, verbose)
+        run_docker(image, home_dir, boot_nodes, verbose)
 
 
 def stop():
@@ -432,12 +433,10 @@ def create_genesis(home, binary_path, nodocker, image, chain_id, tracked_shards)
     print("Genesis created")
 
 
-def start_stakewars(home, binary_path, nodocker, image, telemetry_url, verbose, tracked_shards):
+def start_stakewars(home, binary_path, nodocker, image, verbose, tracked_shards):
     create_genesis(home, binary_path, nodocker, image,
                    'stakewars', tracked_shards)
     if nodocker:
-        run_nodocker(home, binary_path, boot_nodes='',
-                     telemetry_url=telemetry_url, verbose=verbose)
+        run_nodocker(home, binary_path, boot_nodes='', verbose=verbose)
     else:
-        run_docker(image, home, boot_nodes='',
-                   telemetry_url=telemetry_url, verbose=verbose)
+        run_docker(image, home, boot_nodes='', verbose=verbose)

--- a/nearuplib/nodelib.py
+++ b/nearuplib/nodelib.py
@@ -254,6 +254,7 @@ def run_docker(image, home_dir, boot_nodes, verbose):
 def run_nodocker(home_dir, binary_path, boot_nodes, verbose):
     """Runs NEAR core outside of docker."""
     print("Starting NEAR client...")
+    os.environ['RUST_BACKTRACE'] = '1'
     cmd = [f'{binary_path}/near']
     cmd.extend(['--home', home_dir])
     if verbose:


### PR DESCRIPTION
- Use near binary instead of run_near.sh, which supports verbose flag
- Delete telemetry setting because `nearup devnet/betanet/testnet` always use downloaded config.json as a start point. People can then customized boot-nodes as they need but there're rarely needed to customize telemetry-url. If advanced user want to do that, they can do by modifying config.json