### PR TITLE
Watcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # nearup
 
+[![PyPI version](https://badge.fury.io/py/nearup.svg)](https://pypi.org/project/nearup/)
+
 Public scripts to launch near devnet, betanet and testnet node
 
 # Usage
@@ -10,7 +12,7 @@ Before you proceed, make sure you have the following software installed:
 
 * Python 3
 * git (used for updates)
-* cURL (installation only)
+* cURL
 
 ### Ubuntu Prerequisite Installation
 

--- a/main.py
+++ b/main.py
@@ -57,9 +57,7 @@ Run nearup <command> --help to see help for specific command
         self.args = parser.parse_args(sys.argv[2:])
 
     def stop(self):
-        parser = argparse.ArgumentParser(
-            description='Stop the currently running node')
-        self.args = parser.parse_args(sys.argv[2:])
+        self.args = sys.argv[2:]
 
     def logs(self):
         self.args = sys.argv[2:]
@@ -87,7 +85,7 @@ if __name__ == '__main__':
     elif command == 'localnet':
         entry()
     elif command == 'stop':
-        stop()
+        stop(len(args) > 0 and args[0] == '--keep-watcher')
     elif command == 'logs':
         show_logs(len(args) > 0 and (
             args[0] == '-f' or args[0] == '--follow'))

--- a/main.py
+++ b/main.py
@@ -3,6 +3,7 @@ import sys
 from nearuplib.net_argparser import create_net_argparser
 from nearuplib.localnet import entry
 from nearuplib.nodelib import setup_and_run, stop, show_logs
+from nearuplib.util import print
 import os
 
 

--- a/main.py
+++ b/main.py
@@ -80,7 +80,8 @@ if __name__ == '__main__':
         setup_and_run(nodocker, args.binary_path, args.image, args.home,
                       init_flags=init_flags,
                       boot_nodes=args.boot_nodes,
-                      verbose=args.verbose)
+                      verbose=args.verbose,
+                      args=sys.argv[1:])
     if command == 'mainnet':
         print('Sorry mainnet is now internal nodes only, please use https://rpc.mainnet.near.org to reach mainnet rpc')
     elif command == 'localnet':

--- a/nearup
+++ b/nearup
@@ -24,7 +24,9 @@ if os.path.exists(main_script):
     try:
         subprocess.run(args, start_new_session=True)
     except KeyboardInterrupt:
-        pass
+        print('')
+        exit(0)
+
 else:
     p = subprocess.Popen(
         ['git', 'clone', 'https://github.com/nearprotocol/nearup', os.path.expanduser('~/.nearup')], stdout=subprocess.PIPE, stderr=subprocess.PIPE)

--- a/nearuplib/nodelib.py
+++ b/nearuplib/nodelib.py
@@ -1,7 +1,7 @@
 import json
 import os
 import subprocess
-from nearuplib.util import download_near_s3
+from nearuplib.util import download_near_s3, download
 import sys
 import shutil
 import hashlib
@@ -53,6 +53,31 @@ def get_chain_id_from_flags(flags):
     return ''
 
 
+def genesis_changed(chain_id, home_dir):
+    genesis_md5sum = get_genesis_md5sum(chain_id)
+    local_genesis_md5sum = hashlib.md5(open(os.path.join(
+        os.path.join(home_dir, 'genesis.json')), 'rb').read()).hexdigest()
+    if genesis_md5sum == local_genesis_md5sum:
+        print(f'Our genesis version up to date')
+        return False
+    else:
+        print(
+            f'Remote genesis protocol version md5 {genesis_md5sum}, ours is {local_genesis_md5sum}')
+        return True
+
+
+def check_and_update_genesis(chain_id, home_dir):
+    if genesis_changed(chain_id, home_dir):
+        print(
+            f'Update genesis config and remove stale data for {chain_id}')
+        os.remove(os.path.join(home_dir, 'genesis.json'))
+        download_genesis(chain_id, home_dir)
+        if os.path.exists(os.path.join(home_dir, 'data')):
+            shutil.rmtree(os.path.join(home_dir, 'data'))
+        return True
+    return False
+
+
 def check_and_setup(nodocker, binary_path, image, home_dir, init_flags, no_gas_price=False):
     """Checks if there is already everything setup on this machine, otherwise sets up NEAR node."""
     chain_id = get_chain_id_from_flags(init_flags)
@@ -74,36 +99,13 @@ def check_and_setup(nodocker, binary_path, image, home_dir, init_flags, no_gas_p
             exit(1)
 
         if chain_id == 'devnet':
-            genesis_time = get_genesis_time(chain_id)
-            if genesis_time == genesis_config['genesis_time']:
-                print(f'Our genesis version up to date')
-            else:
-                print(
-                    f'Remote genesis time {genesis_time}, ours is {genesis_config["genesis_time"]}')
-                print(
-                    f'Update genesis config and remove stale data for {chain_id}')
-                os.remove(os.path.join(home_dir, 'genesis.json'))
-                download_genesis('devnet', home_dir)
-                if os.path.exists(os.path.join(home_dir, 'data')):
-                    shutil.rmtree(os.path.join(home_dir, 'data'))
+            if check_and_update_genesis(chain_id, home_dir):
+                # For devnet, also update config because boot nodes changed
                 print(f'Update devnet config for new boot nodes')
                 os.remove(os.path.join(home_dir, 'config.json'))
                 download_config('devnet', home_dir)
         elif chain_id in ['betanet', 'testnet']:
-            genesis_md5sum = get_genesis_md5sum(chain_id)
-            local_genesis_md5sum = hashlib.md5(open(os.path.join(
-                os.path.join(home_dir, 'genesis.json')), 'rb').read()).hexdigest()
-            if genesis_md5sum == local_genesis_md5sum:
-                print(f'Our genesis version up to date')
-            else:
-                print(
-                    f'Remote genesis protocol version md5 {genesis_md5sum}, ours is {local_genesis_md5sum}')
-                print(
-                    f'Update genesis config and remove stale data for {chain_id}')
-                os.remove(os.path.join(home_dir, 'genesis.json'))
-                download_genesis(chain_id, home_dir)
-                if os.path.exists(os.path.join(home_dir, 'data')):
-                    shutil.rmtree(os.path.join(home_dir, 'data'))
+            check_and_update_genesis(chain_id, home_dir)
         else:
             print(f'Start {chain_id}')
             print("Using existing node configuration from %s for %s" %
@@ -169,29 +171,54 @@ def latest_deployed_version(net):
     return download_near_s3(f'nearcore-deploy/{net}/latest_deploy')
 
 
-def download_binary(net, uname):
+def docker_changed(image):
+    local_version = subprocess.check_output(
+        ['docker', 'image', 'ls', '-q', '--filter', f'reference={image}']).strip()
+    if local_version:
+        repo, *tag = image.split(':')
+        if tag:
+            tag = tag[0]
+        else:
+            tag = 'latest'
+        auth_token = json.loads(download(
+            f"https://auth.docker.io/token?service=registry.docker.io&scope=repository:{repo}:pull"))['token']
+        image_info = json.loads(download(f"https://index.docker.io/v2/{repo}/manifests/{tag}", headers=[
+                                f"Authorization: Bearer {auth_token}",  "Accept: application/vnd.docker.distribution.manifest.v2+json"]))
+        remote_version = image_info["config"]["digest"].split(':')[1]
+        if remote_version.startswith(local_version):
+            return False
+    return True
+
+
+def binary_changed(net, uname):
     latest_deploy_version = latest_deployed_version(net)
     if os.path.exists(os.path.expanduser(f'~/.nearup/near/{net}/version')):
         with open(os.path.expanduser(f'~/.nearup/near/{net}/version')) as f:
             version = f.read().strip()
             if version == latest_deploy_version:
                 print('Downloaded binary version is up to date')
-                return
-    print(f'Downloading latest deployed version for {net}')
-    download_near_s3(
-        f'nearcore/{uname}/{net_to_branch(net)}/{latest_deploy_version}/near', os.path.expanduser(f'~/.nearup/near/{net}/near'))
-    download_near_s3(
-        f'nearcore/{uname}/{net_to_branch(net)}/{latest_deploy_version}/keypair-generator', os.path.expanduser(f'~/.nearup/near/{net}/keypair-generator'))
-    download_near_s3(
-        f'nearcore/{uname}/{net_to_branch(net)}/{latest_deploy_version}/genesis-csv-to-json', os.path.expanduser(f'~/.nearup/near/{net}/genesis-csv-to-json'))
-    subprocess.check_output(
-        ['chmod', '+x', os.path.expanduser(f'~/.nearup/near/{net}/near')])
-    subprocess.check_output(
-        ['chmod', '+x', os.path.expanduser(f'~/.nearup/near/{net}/keypair-generator')])
-    subprocess.check_output(
-        ['chmod', '+x', os.path.expanduser(f'~/.nearup/near/{net}/genesis-csv-to-json')])
-    with open(os.path.expanduser(f'~/.nearup/near/{net}/version'), 'w') as f:
-        f.write(latest_deploy_version)
+                return False
+    return latest_deploy_version
+
+
+def download_binary(net, uname):
+    latest_deploy_version = binary_changed(net, uname)
+    if latest_deploy_version:
+        print(f'Downloading latest deployed version for {net}')
+        download_near_s3(
+            f'nearcore/{uname}/{net_to_branch(net)}/{latest_deploy_version}/near', os.path.expanduser(f'~/.nearup/near/{net}/near'))
+        download_near_s3(
+            f'nearcore/{uname}/{net_to_branch(net)}/{latest_deploy_version}/keypair-generator', os.path.expanduser(f'~/.nearup/near/{net}/keypair-generator'))
+        download_near_s3(
+            f'nearcore/{uname}/{net_to_branch(net)}/{latest_deploy_version}/genesis-csv-to-json', os.path.expanduser(f'~/.nearup/near/{net}/genesis-csv-to-json'))
+        subprocess.check_output(
+            ['chmod', '+x', os.path.expanduser(f'~/.nearup/near/{net}/near')])
+        subprocess.check_output(
+            ['chmod', '+x', os.path.expanduser(f'~/.nearup/near/{net}/keypair-generator')])
+        subprocess.check_output(
+            ['chmod', '+x', os.path.expanduser(f'~/.nearup/near/{net}/genesis-csv-to-json')])
+        with open(os.path.expanduser(f'~/.nearup/near/{net}/version'), 'w') as f:
+            f.write(latest_deploy_version)
 
 
 def get_genesis_time(net):
@@ -244,7 +271,7 @@ def get_port(home_dir, net):
     return p + ":" + p
 
 
-def run_docker(image, home_dir, boot_nodes, verbose, container_name='nearcore', host_network=False):
+def run_docker(image, home_dir, boot_nodes, verbose, container_name='nearcore', host_network=False, watch=False):
     """Runs NEAR core inside the docker container"""
     print("Starting NEAR client docker...")
     docker_stop_if_exists(container_name)
@@ -276,6 +303,12 @@ def run_docker(image, home_dir, boot_nodes, verbose, container_name='nearcore', 
     except subprocess.CalledProcessError as e:
         print('Failed to run docker near. Error:', file=sys.stderr)
         print(e.stderr, file=sys.stderr)
+        exit(1)
+    if watch:
+        watch_script = os.path.abspath(os.path.join(
+            os.path.dirname(__file__), '..', 'watcher.py'))
+        Popen(['python3', watch_script, watch['net'],
+               home_dir, 'nodocker', *watch['args']])
 
 
 def run_docker_testnet(image, home, *, shards=None, validators=None, non_validators=None):
@@ -305,7 +338,7 @@ def run_docker_testnet(image, home, *, shards=None, validators=None, non_validat
 NODE_PID = os.path.expanduser('~/.nearup/node.pid')
 
 
-def run_binary(path, home, action, *, verbose=None, shards=None, validators=None, non_validators=None, boot_nodes=None, output=None):
+def run_binary(path, home, action, *, verbose=None, shards=None, validators=None, non_validators=None, boot_nodes=None, output=None, watch=False):
     command = [path, '--home', home]
 
     if verbose or verbose == '':
@@ -325,7 +358,13 @@ def run_binary(path, home, action, *, verbose=None, shards=None, validators=None
     if output:
         output = open(f'{output}.log', 'w')
 
-    return Popen(command, stderr=output, stdout=output)
+    near = Popen(command, stderr=output, stdout=output)
+    if watch:
+        watch_script = os.path.abspath(os.path.join(
+            os.path.dirname(__file__), '..', 'watcher.py'))
+        Popen(['python3', watch_script, watch['net'],
+               home, 'nodocker', *watch['args']])
+    return near
 
 
 def proc_name_from_pid(pid):
@@ -354,7 +393,7 @@ def check_exist_neard():
             exit(1)
 
 
-def run_nodocker(home_dir, binary_path, boot_nodes, verbose, chain_id):
+def run_nodocker(home_dir, binary_path, boot_nodes, verbose, chain_id, watch=False):
     """Runs NEAR core outside of docker."""
     print("Starting NEAR client...")
     os.environ['RUST_BACKTRACE'] = '1'
@@ -367,7 +406,7 @@ def run_nodocker(home_dir, binary_path, boot_nodes, verbose, chain_id):
     LOGS_FOLDER = os.path.expanduser('~/.nearup/logs')
     subprocess.check_output(['mkdir', '-p', LOGS_FOLDER])
     proc = run_binary(os.path.join(binary_path, 'near'), home_dir, 'run', verbose=verbose,
-                      boot_nodes=boot_nodes, output=os.path.join(LOGS_FOLDER, chain_id))
+                      boot_nodes=boot_nodes, output=os.path.join(LOGS_FOLDER, chain_id), watch=watch)
     proc_name = proc_name_from_pid(proc.pid)
     print(proc.pid, "|", proc_name, "|", chain_id, file=pid_fd)
     pid_fd.close()
@@ -411,7 +450,7 @@ def check_binary_version(binary_path, chain_id):
             f'Warning: current deployed version on {chain_id} is {latest_deploy_version}, but local binary is {version}. It might not work')
 
 
-def setup_and_run(nodocker, binary_path, image, home_dir, init_flags, boot_nodes, verbose=False, no_gas_price=False):
+def setup_and_run(nodocker, binary_path, image, home_dir, init_flags, boot_nodes, verbose=False, no_gas_price=False, args=None):
     check_exist_neard()
     chain_id = get_chain_id_from_flags(init_flags)
     if nodocker:
@@ -454,9 +493,11 @@ def setup_and_run(nodocker, binary_path, image, home_dir, init_flags, boot_nodes
     print_staking_key(home_dir)
 
     if nodocker:
-        run_nodocker(home_dir, binary_path, boot_nodes, verbose, chain_id)
+        run_nodocker(home_dir, binary_path, boot_nodes, verbose,
+                     chain_id, watch={"args": args, "net": chain_id})
     else:
-        run_docker(image, home_dir, boot_nodes, verbose)
+        run_docker(image, home_dir, boot_nodes, verbose,
+                   watch={"args": args, "net": chain_id})
         print("Node is running! \nTo check logs call: docker logs --follow nearcore")
 
 
@@ -489,6 +530,13 @@ def stop_native():
                 if proc_name in proc_name_from_pid(pid):
                     print(f"Stopping process {proc_name} with pid", pid)
                     kill(pid, SIGTERM)
+                    # Ensure the pid is killed, not just SIGTERM signal sent
+                    while True:
+                        try:
+                            os.kill(pid, 0)
+                        except OSError:
+                            break
+
         unlink(NODE_PID)
 
 

--- a/nearuplib/nodelib.py
+++ b/nearuplib/nodelib.py
@@ -58,7 +58,7 @@ def genesis_changed(chain_id, home_dir):
     local_genesis_md5sum = hashlib.md5(open(os.path.join(
         os.path.join(home_dir, 'genesis.json')), 'rb').read()).hexdigest()
     if genesis_md5sum == local_genesis_md5sum:
-        print(f'Our genesis version up to date')
+        print(f'Our genesis version is up to date')
         return False
     else:
         print(
@@ -190,7 +190,7 @@ def docker_changed(image):
     return True
 
 
-def binary_changed(net, uname):
+def binary_changed(net):
     latest_deploy_version = latest_deployed_version(net)
     if os.path.exists(os.path.expanduser(f'~/.nearup/near/{net}/version')):
         with open(os.path.expanduser(f'~/.nearup/near/{net}/version')) as f:
@@ -202,7 +202,7 @@ def binary_changed(net, uname):
 
 
 def download_binary(net, uname):
-    latest_deploy_version = binary_changed(net, uname)
+    latest_deploy_version = binary_changed(net)
     if latest_deploy_version:
         print(f'Downloading latest deployed version for {net}')
         download_near_s3(

--- a/nearuplib/nodelib.py
+++ b/nearuplib/nodelib.py
@@ -1,7 +1,7 @@
 import json
 import os
 import subprocess
-from nearuplib.util import download_near_s3, download
+from nearuplib.util import download_near_s3, download, print
 import sys
 import shutil
 import hashlib

--- a/nearuplib/util.py
+++ b/nearuplib/util.py
@@ -1,5 +1,6 @@
 import subprocess
 import os
+import builtins
 
 
 def download(url, filepath=None, *, headers=None):
@@ -20,3 +21,7 @@ def download(url, filepath=None, *, headers=None):
 def download_near_s3(path, filepath=None):
     return download(
         f'https://s3-us-west-1.amazonaws.com/build.nearprotocol.com/{path}', filepath)
+
+
+def print(*args, **kwargs):
+    builtins.print(*args, **kwargs, flush=True)

--- a/nearuplib/util.py
+++ b/nearuplib/util.py
@@ -1,15 +1,20 @@
 import subprocess
 import os
 
-def download(url, filepath=None):
+
+def download(url, filepath=None, *, headers=None):
+    if headers:
+        headers = sum(list(map(lambda header: ['-H', header], headers)), [])
+    else:
+        headers = []
     if filepath:
         if os.path.exists(filepath):
             os.remove(filepath)
         subprocess.check_output(
-            ['curl', '--proto', '=https', '--tlsv1.2', '-sSfL', url, '-o', filepath])
+            ['curl', '--proto', '=https', '--tlsv1.2', '-sSfL', *headers, url, '-o', filepath])
     else:
         return subprocess.check_output(
-            ['curl', '--proto', '=https', '--tlsv1.2', '-sSfL', url], universal_newlines=True)
+            ['curl', '--proto', '=https', '--tlsv1.2', '-sSfL', *headers, url], universal_newlines=True)
 
 
 def download_near_s3(path, filepath=None):

--- a/watcher.py
+++ b/watcher.py
@@ -7,6 +7,7 @@ import os
 import subprocess
 import time
 from nearuplib.nodelib import genesis_changed, binary_changed, docker_changed
+from nearuplib.util import print
 
 
 def nearup_restart(args):

--- a/watcher.py
+++ b/watcher.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+# Watch for genesis change, re-nearup when that happens
+# This tool is launched by main.py as a background process
+
+import sys
+import os
+import subprocess
+import time
+from nearuplib.nodelib import genesis_changed, binary_changed, docker_changed
+
+
+def nearup_restart(args):
+    main_script = os.path.abspath(os.path.join(
+        os.path.dirname(__file__), 'main.py'))
+    print(subprocess.check_output(['python3', main_script, 'stop']))
+    subprocess.Popen(
+        ['python3', main_script, *args])
+    print('done')
+
+
+if __name__ == '__main__':
+    net = sys.argv[1]
+    home_dir = sys.argv[2]
+    docker = sys.argv[3]
+    args = sys.argv[4:]
+
+    while True:
+        time.sleep(60)
+        if genesis_changed(net, home_dir):
+            nearup_restart(args)
+            exit(0)
+        elif docker == 'nodocker' and binary_changed(net, os.uname()[0]):
+            nearup_restart(args)
+            exit(0)
+        elif docker == 'docker' and docker_changed(net):
+            nearup_restart(args)
+            exit(0)

--- a/watcher.py
+++ b/watcher.py
@@ -12,7 +12,7 @@ from nearuplib.nodelib import genesis_changed, binary_changed, docker_changed
 def nearup_restart(args):
     main_script = os.path.abspath(os.path.join(
         os.path.dirname(__file__), 'main.py'))
-    print(subprocess.check_output(['python3', main_script, 'stop']))
+    subprocess.check_output(['python3', main_script, 'stop', '--keep-watcher'])
     subprocess.Popen(
         ['python3', main_script, *args])
     print('done')

--- a/watcher.py
+++ b/watcher.py
@@ -29,7 +29,7 @@ if __name__ == '__main__':
         if genesis_changed(net, home_dir):
             nearup_restart(args)
             exit(0)
-        elif docker == 'nodocker' and binary_changed(net, os.uname()[0]):
+        elif docker == 'nodocker' and binary_changed(net):
             nearup_restart(args)
             exit(0)
         elif docker == 'docker' and docker_changed(net):


### PR DESCRIPTION
when start with new nearup (python3 main.py anynet ... in this branch), a background watch process is also spawned. It watch for: genesis change, new binary, new docker image. Doing nearup stop and re nearup with same args. When nearup stop, it stop both the near (near docker) and the watcher process. Tested with devnet.