### PR TITLE
Added psutil instead of the custom implemented function to translate …

### DIFF
--- a/nearuplib/localnet.py
+++ b/nearuplib/localnet.py
@@ -1,12 +1,15 @@
-import sys
 import argparse
 import configparser
-from subprocess import Popen, PIPE
-from shutil import rmtree
+import json
+import psutil
+import sys
+
 from os import mkdir
 from os.path import exists, expanduser, join
-import json
-from nearuplib.nodelib import run_binary, NODE_PID, proc_name_from_pid, run_docker_testnet, run_docker, check_exist_neard
+from subprocess import Popen, PIPE
+from shutil import rmtree
+
+from nearuplib.nodelib import run_binary, NODE_PID, run_docker_testnet, run_docker, check_exist_neard
 
 
 def run(args):
@@ -67,7 +70,7 @@ def run(args):
                 verbose=args.verbose,
                 boot_nodes=f'{pk}@127.0.0.1:24567' if i > 0 else None,
                 output=join(LOGS_FOLDER, f'node{i}'))
-            proc_name = proc_name_from_pid(proc.pid)
+            proc_name = psutil.Process(proc.pid).name()
             print(proc.pid, "|", proc_name, "|", 'localnet', file=pid_fd)
         pid_fd.close()
 

--- a/setup.py
+++ b/setup.py
@@ -15,17 +15,21 @@ setuptools.setup(
     packages=setuptools.find_packages(),
     classifiers=[
         "Programming Language :: Python :: 3",
-        "Development Status :: 3 - Alpha", "Intended Audience :: Developers",
+        "Development Status :: 3 - Alpha",
+        "Intended Audience :: Developers",
         "Intended Audience :: System Administrators",
         "License :: OSI Approved :: BSD License",
         "Operating System :: MacOS :: MacOS X",
-        "Operating System :: POSIX :: Linux", "Topic :: System :: Clustering",
+        "Operating System :: POSIX :: Linux",
+        "Topic :: System :: Clustering",
         "Topic :: System :: Distributed Computing",
         "Topic :: System :: Installation/Setup",
         "Topic :: System :: Systems Administration",
-        "Topic :: System :: Networking"
+        "Topic :: System :: Networking",
     ],
-    install_requires=[],
+    install_requires=[
+        "psutil",
+    ],
     python_requires='>=3.6',
     # scripts=['nearup'] # Intentionally no scripts, use as lib only if installed from pypi
 )


### PR DESCRIPTION
…procname from pid

Test Plan:
```
sandi@sandi-ThinkPad-X1-Carbon-7th ~/w/n/nearup (master)>
python3 main.py localnet --binary-path ~/workspace/near/core/target/debug/
Local network was spawned successfully.
Check logs at: /home/sandi/.nearup/localnet-logs
Check network status at http://127.0.0.1:3030/status
sandi@sandi-ThinkPad-X1-Carbon-7th ~/w/n/nearup (master)>
python3 main.py localnet --binary-path ~/workspace/near/core/target/debug/
There is already binary nodes running. Stop it using:
nearup stop
If this is a mistake, remove /home/sandi/.nearup/node.pid
sandi@sandi-ThinkPad-X1-Carbon-7th ~/w/n/nearup (master) [1]>
python3 main.py localnet --binary-path ~/workspace/near/core/target/debug/
There is already binary nodes running. Stop it using:
nearup stop
If this is a mistake, remove /home/sandi/.nearup/node.pid
sandi@sandi-ThinkPad-X1-Carbon-7th ~/w/n/nearup (master) [1]> ~/.nearup/nearup stop^C
sandi@sandi-ThinkPad-X1-Carbon-7th ~/w/n/nearup (master) [1]> python3 nearup stop
sandi@sandi-ThinkPad-X1-Carbon-7th ~/w/n/nearup (master)>
python3 main.py localnet --binary-path ~/workspace/near/core/target/debug/
Local network was spawned successfully.
Check logs at: /home/sandi/.nearup/localnet-logs
Check network status at http://127.0.0.1:3030/status
```