### PR TITLE
Add different message if nearup is installed

### DIFF
--- a/nearup
+++ b/nearup
@@ -4,6 +4,11 @@ import subprocess
 import sys
 import platform
 
+STARTUP_MESSAGE = '''To get started you need Nearup's directory ($HOME/.nearup) in your PATH
+environment variable. Next time you log in this will be done automatically.
+
+To configure your current shell run `source $HOME/.nearup/env`'''
+
 version = platform.python_version_tuple()
 major_version = int(version[0])
 minor_version = int(version[1])
@@ -18,9 +23,9 @@ if not os.path.exists(main_script):
         'git', 'clone', 'https://github.com/nearprotocol/nearup',
         os.path.expanduser('~/.nearup')
     ],
-                         stdout=subprocess.PIPE,
-                         stderr=subprocess.PIPE,
-                         universal_newlines=True)
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        universal_newlines=True)
     _stdout, stderr = p.communicate()
     if p.returncode != 0:
         sys.stderr.write('Failed to obtain nearup. Error:\n')
@@ -46,11 +51,11 @@ if not os.path.exists(main_script):
         add_path_if_exist('~/.zprofile')
         add_path_if_exist('~/.config/fish')
         add_path_if_exist('~/.bash_profile')
-        print(
-            '''To get started you need Nearup's directory ($HOME/.nearup) in your PATH
-environment variable. Next time you log in this will be done automatically.
+        print(STARTUP_MESSAGE)
+else:
+    print("\nWarning: Nearup was already installed in ~/.nearup!\n")
+    print(STARTUP_MESSAGE)
 
-To configure your current shell run `source $HOME/.nearup/env`''')
 
 p = subprocess.Popen('cd ' + nearup_dir + ' && git pull',
                      stdout=subprocess.PIPE,
@@ -61,5 +66,10 @@ _stdout, stderr = p.communicate()
 if p.returncode != 0:
     sys.stderr.write('Warning: Failed to update nearup. Error:\n')
     sys.stderr.write(stderr + '\n')
+
 args = ['python3', main_script] + sys.argv[1:]
+
+if len(args) == 2:
+    args += ['--help']
+
 os.execvp(args[0], args)


### PR DESCRIPTION
Also remove annoying/confusing error message on first usage

```
nearup: error: the following arguments are required: command
```

fixes: #92 