### PR TITLE
Remove warning always.

### DIFF
--- a/nearup
+++ b/nearup
@@ -52,9 +52,6 @@ if not os.path.exists(main_script):
         add_path_if_exist('~/.config/fish')
         add_path_if_exist('~/.bash_profile')
         print(STARTUP_MESSAGE)
-else:
-    print("\nWarning: Nearup was already installed in ~/.nearup!\n")
-    print(STARTUP_MESSAGE)
 
 
 p = subprocess.Popen('cd ' + nearup_dir + ' && git pull',


### PR DESCRIPTION
Fixes #96

It is not clear how to differentiate between an install using curl, from an autoupdate. 

The easier solution I see is passing an extra flag to the `nearup` script (`--download`), or using an environment variable. But either options requires to change the one-liner used today to install `nearup`. 

Another option is to use different script at `https://up.near.dev` (different by just one flag is enough), but then it requires extra steps for deploying and maintenance.