### PR TITLE
fix: small change - very confusing point for beginners

### DIFF
--- a/nearuplib/nodelib.py
+++ b/nearuplib/nodelib.py
@@ -116,7 +116,7 @@ def check_and_setup(nodocker,
     print("Setting up network configuration.")
     account_id = [x for x in init_flags if x.startswith('--account-id')]
     if not account_id:
-        prompt = "Enter your account ID"
+        prompt = "Enter your Staking-Pool-contract ID (xxxxx.stakehouse.betanet)"
         if chain_id != '':
             prompt += " (leave empty if not going to be a validator): "
         else:


### PR DESCRIPTION
when a new validator node is installed it asks to "Enter your account_id", when what we really need is the Staking-Pool contract ID. This is a point where every newcomer makes mistake that leads to problems later, confusion, etc.
Because this is an ID asked at installation, failing to enter the proper id, leads a beginner to believe they have to rm everything and start again.
relates to #59 