### PR TITLE
Update README for mac development and improve integration tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,6 +132,11 @@ dmypy.json
 near
 # Near source code
 nearcore
+# Near data and configuration
+config.json
+data/
+genesis.json
+node_key.json
 
 # IDE
 .vscode/

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ RUN apt-get update && apt-get install -y python3 python3-pip && pip3 install --u
 ENV LANG C.UTF-8  
 ENV LC_ALL C.UTF-8     
 ENV PATH="/root/.local/bin:$PATH"
+ENV HOME="/root"
 COPY ./start.sh /root/start.sh
 RUN chmod +x /root/start.sh
 

--- a/README.md
+++ b/README.md
@@ -147,3 +147,21 @@ To eventually kill the docker container run:
 ```
 docker kill nearup
 ```
+
+# Development
+
+Currently, nearup expects the test environment to be run on Linux.
+
+For macOS, you can simulate a Linux environment with docker.
+
+To build a development image,
+
+```
+docker build . -t nearprotocol/nearup:dev
+```
+
+The following will mount your repo directory into the running container and drop you into a shell to run test commands.
+
+```
+docker run -it --entrypoint "" -v $PWD:/root/nearup -v $HOME/.near:/root/.near -w /root/nearup nearprotocol/nearup:dev bash
+```

--- a/nearuplib/constants.py
+++ b/nearuplib/constants.py
@@ -5,3 +5,4 @@ LOCALNET_LOGS_FOLDER = os.path.expanduser("~/.nearup/logs/localnet")
 NODE_PID_FILE = os.path.expanduser('~/.nearup/node.pid')
 S3_BUCKET = 'build.nearprotocol.com'
 WATCHER_PID_FILE = os.path.expanduser('~/.nearup/watcher.pid')
+DEFAULT_WAIT_TIMEOUT = 30

--- a/nearuplib/nodelib.py
+++ b/nearuplib/nodelib.py
@@ -294,7 +294,7 @@ def restart_nearup(net,
     logging.info("Nearup has been restarted...")
 
 
-def stop_native(timeout=None):
+def stop_native(timeout=DEFAULT_WAIT_TIMEOUT):
     try:
         if os.path.exists(NODE_PID_FILE):
             with open(NODE_PID_FILE) as pid_file:
@@ -308,7 +308,7 @@ def stop_native(timeout=None):
                         logging.info(
                             f"Stopping process {proc_name} with pid {pid}...")
                         process.terminate()
-                        process.wait(timeout=timeout if timeout else DEFAULT_WAIT_TIMEOUT)
+                        process.wait(timeout=timeout)
             os.remove(NODE_PID_FILE)
         else:
             logging.info("Near deamon is not running...")

--- a/nearuplib/nodelib.py
+++ b/nearuplib/nodelib.py
@@ -10,7 +10,7 @@ from subprocess import Popen
 
 import psutil
 
-from nearuplib.constants import LOGS_FOLDER, NODE_PID_FILE
+from nearuplib.constants import DEFAULT_WAIT_TIMEOUT, LOGS_FOLDER, NODE_PID_FILE
 from nearuplib.util import (
     download_binaries,
     download_config,
@@ -294,7 +294,7 @@ def restart_nearup(net,
     logging.info("Nearup has been restarted...")
 
 
-def stop_native():
+def stop_native(timeout=None):
     try:
         if os.path.exists(NODE_PID_FILE):
             with open(NODE_PID_FILE) as pid_file:
@@ -308,6 +308,7 @@ def stop_native():
                         logging.info(
                             f"Stopping process {proc_name} with pid {pid}...")
                         process.kill()
+                        process.wait(timeout=timeout if timeout else DEFAULT_WAIT_TIMEOUT)
             os.remove(NODE_PID_FILE)
         else:
             logging.info("Near deamon is not running...")

--- a/nearuplib/nodelib.py
+++ b/nearuplib/nodelib.py
@@ -307,7 +307,7 @@ def stop_native(timeout=None):
                     if proc_name in proc_name_from_pid(pid):
                         logging.info(
                             f"Stopping process {proc_name} with pid {pid}...")
-                        process.kill()
+                        process.terminate()
                         process.wait(timeout=timeout if timeout else DEFAULT_WAIT_TIMEOUT)
             os.remove(NODE_PID_FILE)
         else:

--- a/nearuplib/util.py
+++ b/nearuplib/util.py
@@ -118,7 +118,7 @@ def generate_validator_key(home, binary_path, account_id):
     generate_key(cmd, 'validator key')
 
 
-def initialize_keys(home, binary_path, account_id):
+def initialize_keys(home, binary_path, account_id=None):
     logging.info("Generating the node keys...")
     generate_node_key(home, binary_path)
 

--- a/nearuplib/watcher.py
+++ b/nearuplib/watcher.py
@@ -6,7 +6,7 @@ from subprocess import Popen
 
 import psutil
 
-from nearuplib.constants import WATCHER_PID_FILE
+from nearuplib.constants import DEFAULT_WAIT_TIMEOUT, WATCHER_PID_FILE
 
 
 def run_watcher(net, path=os.path.expanduser('~/.local/bin/watcher')):
@@ -27,7 +27,7 @@ def run_watcher(net, path=os.path.expanduser('~/.local/bin/watcher')):
         watcher_pid_file.write(str(proc.pid))
 
 
-def stop_watcher():
+def stop_watcher(timeout=None):
     try:
         if os.path.exists(WATCHER_PID_FILE):
             with open(WATCHER_PID_FILE) as pid_file:
@@ -35,7 +35,8 @@ def stop_watcher():
                 process = psutil.Process(pid)
                 logging.info(
                     f'Stopping near watcher {process.name()} with pid {pid}...')
-                process.kill()
+                process.terminate()
+                process.wait(timeout=timeout if timeout else DEFAULT_WAIT_TIMEOUT)
                 os.remove(WATCHER_PID_FILE)
         else:
             logging.info("Nearup watcher is not running...")

--- a/nearuplib/watcher.py
+++ b/nearuplib/watcher.py
@@ -27,7 +27,7 @@ def run_watcher(net, path=os.path.expanduser('~/.local/bin/watcher')):
         watcher_pid_file.write(str(proc.pid))
 
 
-def stop_watcher(timeout=None):
+def stop_watcher(timeout=DEFAULT_WAIT_TIMEOUT):
     try:
         if os.path.exists(WATCHER_PID_FILE):
             with open(WATCHER_PID_FILE) as pid_file:
@@ -36,7 +36,7 @@ def stop_watcher(timeout=None):
                 logging.info(
                     f'Stopping near watcher {process.name()} with pid {pid}...')
                 process.terminate()
-                process.wait(timeout=timeout if timeout else DEFAULT_WAIT_TIMEOUT)
+                process.wait(timeout=timeout)
                 os.remove(WATCHER_PID_FILE)
         else:
             logging.info("Nearup watcher is not running...")

--- a/tests/test_key_generation.py
+++ b/tests/test_key_generation.py
@@ -37,6 +37,7 @@ def assert_node_key():
         assert 'public_key' in data
         assert 'secret_key' in data
 
+
 def assert_validator_key():
     validator_key_path = os.path.join(HOME, 'validator_key.json')
     assert os.path.exists(validator_key_path)

--- a/tests/test_key_generation.py
+++ b/tests/test_key_generation.py
@@ -4,7 +4,7 @@ import shutil
 
 import pytest
 
-from nearuplib.util import generate_node_key, generate_validator_key
+from nearuplib.util import generate_node_key, generate_validator_key, initialize_keys
 from nearuplib.nodelib import download_binaries
 
 HOME = os.path.expanduser('~/.near/betanet')
@@ -27,10 +27,7 @@ def setup_module(module):  # pylint: disable=W0613
     download_binaries('betanet', 'Linux')
 
 
-@pytest.mark.run(order=0)
-def test_generate_node_key():
-    generate_node_key(HOME, BINARY_PATH)
-
+def assert_node_key():
     node_key_path = os.path.join(HOME, 'node_key.json')
     assert os.path.exists(node_key_path)
 
@@ -40,15 +37,7 @@ def test_generate_node_key():
         assert 'public_key' in data
         assert 'secret_key' in data
 
-    with pytest.raises(SystemExit) as err:
-        generate_node_key(HOME, WRONG_BINARY_PATH)
-    assert err.value.code == 1
-
-
-@pytest.mark.run(order=1)
-def test_generate_validator_key():
-    generate_validator_key(HOME, BINARY_PATH, ACCOUNT_ID)
-
+def assert_validator_key():
     validator_key_path = os.path.join(HOME, 'validator_key.json')
     assert os.path.exists(validator_key_path)
 
@@ -58,6 +47,35 @@ def test_generate_validator_key():
         assert 'public_key' in data
         assert 'secret_key' in data
 
+
+@pytest.mark.run(order=0)
+def test_generate_node_key():
+    generate_node_key(HOME, BINARY_PATH)
+    assert_node_key()
+
+    with pytest.raises(SystemExit) as err:
+        generate_node_key(HOME, WRONG_BINARY_PATH)
+    assert err.value.code == 1
+
+
+@pytest.mark.run(order=1)
+def test_generate_validator_key():
+    generate_validator_key(HOME, BINARY_PATH, ACCOUNT_ID)
+    assert_validator_key()
+
     with pytest.raises(SystemExit) as err:
         generate_validator_key(HOME, WRONG_BINARY_PATH, ACCOUNT_ID)
     assert err.value.code == 1
+
+
+@pytest.mark.run(order=2)
+def test_initialize_keys_no_validator():
+    initialize_keys(HOME, BINARY_PATH)
+    assert_node_key()
+
+
+@pytest.mark.run(order=3)
+def test_initialize_keys_validator():
+    initialize_keys(HOME, BINARY_PATH, ACCOUNT_ID)
+    assert_node_key()
+    assert_validator_key()

--- a/tests/test_nearup_integration_test.py
+++ b/tests/test_nearup_integration_test.py
@@ -4,7 +4,7 @@ import shutil
 import pytest
 import requests
 from requests.adapters import HTTPAdapter
-from requests.packages.urllib3.util.retry import Retry
+from urllib3.util.retry import Retry
 
 from nearuplib.nodelib import restart_nearup, setup_and_run, stop_nearup
 from nearuplib.constants import LOGS_FOLDER

--- a/tests/test_nearup_integration_test.py
+++ b/tests/test_nearup_integration_test.py
@@ -1,6 +1,5 @@
 import os
 import shutil
-import time
 
 import pytest
 import requests

--- a/tests/test_nodelib.py
+++ b/tests/test_nodelib.py
@@ -1,0 +1,86 @@
+import json
+import os
+import shutil
+from pathlib import Path
+
+import pytest
+
+from nearuplib.nodelib import check_and_setup
+
+ACCOUNT_ID = 'mock.nearup.account'
+BETANET_HOME = os.path.expanduser('~/.near/betanet')
+BETANET_BINARY_PATH = os.path.expanduser('~/.near/near/betanet')
+BETANET_INIT_FLAGS = ['--chain-id=betanet', f'--account-id={ACCOUNT_ID}']
+LOCALNET_HOME = os.path.expanduser('~/.near/localnet')
+LOCALNET_BINARY_PATH = os.path.expanduser('~/.near/near/localnet')
+LOCALNET_INIT_FLAGS = ['--chain-id=localnet']
+
+
+def cleanup():
+    if os.path.exists(LOCALNET_HOME):
+        shutil.rmtree(LOCALNET_HOME)
+
+    if os.path.exists(BETANET_HOME):
+        shutil.rmtree(BETANET_HOME)
+
+
+def setup_module(module):  # pylint: disable=W0613
+    cleanup()
+    os.makedirs(BETANET_HOME)
+    os.makedirs(LOCALNET_HOME)
+
+
+def teardown_module(module):  # pylint: disable=W0613
+    cleanup()
+
+
+def write_config_files(home):
+    Path(f'{home}/node_key.json').touch()
+    Path(f'{home}/config.json').touch()
+    Path(f'{home}/genesis.json').touch()
+
+
+def write_genesis(home, chain_id):
+    with open(f'{home}/genesis.json', 'w') as genesis:
+        json.dump({'chain_id': chain_id}, genesis)
+
+
+def test_check_and_setup_localnet_missing_files():
+    """Home directory exists, but missing key files"""
+    with pytest.raises(SystemExit) as err:
+        check_and_setup(LOCALNET_BINARY_PATH, LOCALNET_HOME, LOCALNET_INIT_FLAGS)
+
+    assert err.value.code == 1
+
+
+def test_check_and_setup_localnet_bad_chain_id():
+    """Home directory genesis.json has different chain_id"""
+    write_config_files(LOCALNET_HOME)
+    write_genesis(LOCALNET_HOME, 'not_localnet')
+
+    with pytest.raises(SystemExit) as err:
+        check_and_setup(LOCALNET_BINARY_PATH, LOCALNET_HOME, LOCALNET_INIT_FLAGS)
+
+    assert err.value.code == 1
+
+
+def test_check_and_setup_localnet_existing_config():
+    """Home directory exists with config"""
+    write_config_files(LOCALNET_HOME)
+    write_genesis(LOCALNET_HOME, 'localnet')
+
+    try:
+        check_and_setup(LOCALNET_BINARY_PATH, LOCALNET_HOME, LOCALNET_INIT_FLAGS)
+    except Exception as ex:
+        pytest.fail(f'unexpected expection {ex}')
+
+
+def test_check_and_setup_betanet_existing_config():
+    """Home directory for betanet exists with config"""
+    write_config_files(BETANET_HOME)
+    write_genesis(BETANET_HOME, 'betanet')
+
+    try:
+        check_and_setup(BETANET_BINARY_PATH, BETANET_HOME, BETANET_INIT_FLAGS)
+    except Exception as ex:
+        pytest.fail(f'unexpected exception {ex}')

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -1,5 +1,7 @@
 import os
 
+import pytest
+
 from nearuplib.constants import WATCHER_PID_FILE
 from nearuplib.watcher import run_watcher, stop_watcher
 
@@ -20,3 +22,10 @@ def test_running_and_stopping_watcher():
 
     stop_watcher()
     assert not os.path.exists(WATCHER_PID_FILE)
+
+
+def test_running_bad_path():
+    with pytest.raises(SystemExit) as err:
+        run_watcher('betanet', os.path.expanduser('~/does/not/exist'))
+
+    assert err.value.code == 1

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py37
+envlist = py3
 
 [testenv]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ envlist = py3
 deps =
     pytest
     pytest-ordering
-		requests
+	requests
 commands =
     pytest tests
 
@@ -17,9 +17,9 @@ deps =
     pytest >= 6.0.1
     pytest-cov
     pytest-ordering
-		requests
+	requests
 commands =
-    pytest --cov=nearuplib tests
+    pytest --cov-report html:htmlcov --cov=nearuplib tests
 
 [testenv:style]
 deps =
@@ -30,7 +30,7 @@ commands = yapf --diff -r nearup ./**/*.py
 deps =
     pylint >= 2.6.0
     pytest >= 6.0.1
-		requests
+	requests
 allowlist_externals = bash
 commands = bash ./scripts/pylint.sh
 

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ envlist = py3
 deps =
     pytest
     pytest-ordering
-	requests
+    requests
 commands =
     pytest tests
 
@@ -17,9 +17,9 @@ deps =
     pytest >= 6.0.1
     pytest-cov
     pytest-ordering
-	requests
+    requests
 commands =
-    pytest --cov-report html:htmlcov --cov=nearuplib tests
+    pytest --cov-report term --cov-report html:htmlcov --cov=nearuplib tests
 
 [testenv:style]
 deps =
@@ -30,7 +30,7 @@ commands = yapf --diff -r nearup ./**/*.py
 deps =
     pylint >= 2.6.0
     pytest >= 6.0.1
-	requests
+    requests
 allowlist_externals = bash
 commands = bash ./scripts/pylint.sh
 

--- a/watcher
+++ b/watcher
@@ -49,7 +49,7 @@ def run(network):
                 logging.info(
                     f"New release has been published. Restarting nearup")
                 restart_nearup(net)
-                break
+                continue
         except:
             traceback.print_exc()
             pass

--- a/watcher
+++ b/watcher
@@ -49,7 +49,7 @@ def run(network):
                 logging.info(
                     f"New release has been published. Restarting nearup")
                 restart_nearup(net)
-                continue
+                break
         except:
             traceback.print_exc()
             pass


### PR DESCRIPTION
* Updates README for mac development
* Set `tox` environment to `py3`
* Pass a configurable timeout (with a default of 30 seconds) to the process termination to improve local consistency (slower CPU) and test readability (no sleeps)
* Use `process.terminate()` instead of `process.kill()` to allow for graceful shutdown (This could probably be improved further by doing a `kill()` if the `terminate()` doesn't return within a configured grace period, but this is a start.)
* increase `nodelib` coverage