### PR TITLE
Remove the key-generator code from nearup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,10 @@
 from ubuntu:18.04
 
-RUN apt-get update && apt-get install -y python3 python3-pip && pip3 install --upgrade pip && pip3 install --user nearup==0.5.2
+RUN apt-get update && \
+    apt-get install -y python3 python3-pip && \
+    pip3 install --upgrade pip && \
+    pip3 install --user tox && \
+    pip3 install --user nearup==0.5.2
 
 ENV LANG C.UTF-8  
 ENV LC_ALL C.UTF-8     

--- a/nearuplib/util.py
+++ b/nearuplib/util.py
@@ -1,8 +1,6 @@
 import logging
 import os
 import stat
-import subprocess
-import sys
 
 import boto3
 from botocore import UNSIGNED
@@ -39,7 +37,7 @@ def download_binaries(net, uname):
     if commit:
         logging.info(f'Downloading latest deployed version for {net}')
 
-        binaries = ['near', 'keypair-generator', 'genesis-csv-to-json']
+        binaries = ['near', 'genesis-csv-to-json']
         for binary in binaries:
             download_url = f'nearcore/{uname}/{branch}/{commit}/{binary}'
             download_path = os.path.expanduser(f'~/.nearup/near/{net}/{binary}')
@@ -86,42 +84,3 @@ def latest_deployed_release_time(net):
 
 def latest_genesis_md5sum(net):
     return read_from_s3(f'nearcore-deploy/{net}/genesis_md5sum').strip()
-
-
-def generate_key(cmd, key):
-    logging.info(f"Generating {key}...")
-
-    try:
-        subprocess.check_call(cmd, stdout=subprocess.PIPE)
-    except KeyboardInterrupt:
-        logging.error("\nStopping NEARCore.")
-    except (subprocess.CalledProcessError, FileNotFoundError):
-        logging.error(f"Unable to generate {key}.")
-        sys.exit(1)
-
-    logging.info(f"{key.capitalize()} generated...")
-
-
-def generate_node_key(home, binary_path):
-    cmd = [
-        f'{binary_path}/keypair-generator', '--home', home, '--generate-config',
-        'node-key'
-    ]
-    generate_key(cmd, 'node key')
-
-
-def generate_validator_key(home, binary_path, account_id):
-    cmd = [
-        f'{binary_path}/keypair-generator', '--home', home, '--generate-config',
-        '--account-id', account_id, 'validator-key'
-    ]
-    generate_key(cmd, 'validator key')
-
-
-def initialize_keys(home, binary_path, account_id=None):
-    logging.info("Generating the node keys...")
-    generate_node_key(home, binary_path)
-
-    if account_id:
-        logging.info("Generating the validator keys...")
-        generate_validator_key(home, binary_path, account_id)

--- a/tests/test_download_binaries.py
+++ b/tests/test_download_binaries.py
@@ -22,7 +22,7 @@ def setup_module(module):  # pylint: disable=W0613
 def test_download_binaries():
     download_binaries('betanet', 'Linux')
 
-    expected_binaries = ['near', 'keypair-generator', 'genesis-csv-to-json']
+    expected_binaries = ['near', 'genesis-csv-to-json']
     for binary in expected_binaries:
         path = os.path.join(NEARUP_BINARY_DIR, binary)
         # check if the binary exists

--- a/tests/test_key_generation.py
+++ b/tests/test_key_generation.py
@@ -2,14 +2,10 @@ import json
 import os
 import shutil
 
-import pytest
-
-from nearuplib.util import generate_node_key, generate_validator_key, initialize_keys
-from nearuplib.nodelib import download_binaries
+from nearuplib.nodelib import download_binaries, init_near
 
 HOME = os.path.expanduser('~/.near/betanet')
 BINARY_PATH = os.path.expanduser('~/.nearup/near/betanet')
-WRONG_BINARY_PATH = os.path.expanduser('~/.nearup/near/testnet')
 NEARUP_PATH = os.path.expanduser('~/.nearup/')
 ACCOUNT_ID = 'mock.nearup.account'
 
@@ -49,34 +45,7 @@ def assert_validator_key():
         assert 'secret_key' in data
 
 
-@pytest.mark.run(order=0)
-def test_generate_node_key():
-    generate_node_key(HOME, BINARY_PATH)
-    assert_node_key()
-
-    with pytest.raises(SystemExit) as err:
-        generate_node_key(HOME, WRONG_BINARY_PATH)
-    assert err.value.code == 1
-
-
-@pytest.mark.run(order=1)
-def test_generate_validator_key():
-    generate_validator_key(HOME, BINARY_PATH, ACCOUNT_ID)
-    assert_validator_key()
-
-    with pytest.raises(SystemExit) as err:
-        generate_validator_key(HOME, WRONG_BINARY_PATH, ACCOUNT_ID)
-    assert err.value.code == 1
-
-
-@pytest.mark.run(order=2)
-def test_initialize_keys_no_validator():
-    initialize_keys(HOME, BINARY_PATH)
-    assert_node_key()
-
-
-@pytest.mark.run(order=3)
-def test_initialize_keys_validator():
-    initialize_keys(HOME, BINARY_PATH, ACCOUNT_ID)
+def test_init_near():
+    init_near(HOME, BINARY_PATH, 'betanet', ['--chain-id=betanet', f'--account-id={ACCOUNT_ID}'])
     assert_node_key()
     assert_validator_key()


### PR DESCRIPTION
Delegates key generation to `near init` on `nearup run`
Resolves #103 