### PR TITLE
Try process.terminate(), fallback to process.kill()

### DIFF
--- a/nearuplib/nodelib.py
+++ b/nearuplib/nodelib.py
@@ -291,13 +291,22 @@ def stop_native(timeout=DEFAULT_WAIT_TIMEOUT):
                     pid, proc_name, _ = line.strip().split("|")
                     pid = int(pid)
                     process = psutil.Process(pid)
-                    logging.info(
-                        f"Near procces is {proc_name} with pid: {pid}...")
+                    logging.info(f"Near procces is {proc_name} with pid: {pid}...")
+
                     if proc_name in proc_name_from_pid(pid):
-                        logging.info(
-                            f"Stopping process {proc_name} with pid {pid}...")
-                        process.kill()
-                        process.wait(timeout=timeout)
+                        logging.info(f"Stopping process {proc_name} with pid {pid}...")
+                        try:
+                            process.terminate()
+                            process.wait(timeout=timeout)
+                        except psutil.TimeoutExpired:
+                            logging.warning(
+                                f"Process {proc_name} with pid {pid} is taking a long time to terminate..."
+                            )
+                            logging.warning(
+                                f"Killing process {pid}"
+                            )
+                            process.kill()
+
             os.remove(NODE_PID_FILE)
         else:
             logging.info("Near deamon is not running...")

--- a/nearuplib/nodelib.py
+++ b/nearuplib/nodelib.py
@@ -300,10 +300,7 @@ def stop_native(timeout=DEFAULT_WAIT_TIMEOUT):
                             process.wait(timeout=timeout)
                         except psutil.TimeoutExpired:
                             logging.warning(
-                                f"Process {proc_name} with pid {pid} is taking a long time to terminate..."
-                            )
-                            logging.warning(
-                                f"Killing process {pid}"
+                                f"Timeout expired. Killing process {pid}"
                             )
                             process.kill()
 

--- a/nearuplib/nodelib.py
+++ b/nearuplib/nodelib.py
@@ -296,7 +296,7 @@ def stop_native(timeout=DEFAULT_WAIT_TIMEOUT):
                     if proc_name in proc_name_from_pid(pid):
                         logging.info(
                             f"Stopping process {proc_name} with pid {pid}...")
-                        process.terminate()
+                        process.kill()
                         process.wait(timeout=timeout)
             os.remove(NODE_PID_FILE)
         else:

--- a/nearuplib/watcher.py
+++ b/nearuplib/watcher.py
@@ -35,7 +35,7 @@ def stop_watcher(timeout=DEFAULT_WAIT_TIMEOUT):
                 process = psutil.Process(pid)
                 logging.info(
                     f'Stopping near watcher {process.name()} with pid {pid}...')
-                process.terminate()
+                process.kill()
                 process.wait(timeout=timeout)
                 os.remove(WATCHER_PID_FILE)
         else:

--- a/nearuplib/watcher.py
+++ b/nearuplib/watcher.py
@@ -33,10 +33,16 @@ def stop_watcher(timeout=DEFAULT_WAIT_TIMEOUT):
             with open(WATCHER_PID_FILE) as pid_file:
                 pid = int(pid_file.read())
                 process = psutil.Process(pid)
-                logging.info(
-                    f'Stopping near watcher {process.name()} with pid {pid}...')
-                process.kill()
-                process.wait(timeout=timeout)
+                logging.info(f'Stopping near watcher {process.name()} with pid {pid}...')
+
+                try:
+                    process.terminate()
+                    process.wait(timeout=timeout)
+                except psutil.TimeoutExpired:
+                    logging.warning('Watcher taking a long time to terminate...')
+                    logging.warning('Killing watcher with pid {pid}')
+                    process.kill()
+
                 os.remove(WATCHER_PID_FILE)
         else:
             logging.info("Nearup watcher is not running...")


### PR DESCRIPTION
According to @bowenwang1996, `neard` doesn't really handle SIGTERMs properly, and this is causing some issues with `nearup` when it tries to restart.

This will first try `process.terminate()`, and if that does not complete within the wait timeout, fallback to `process.kill()`