### PR TITLE
fix setup and restart to use named directory for home

### DIFF
--- a/nearup
+++ b/nearup
@@ -87,7 +87,7 @@ def run(network, binary_path, home, account_id, boot_nodes, verbose, num_nodes,
             init_flags.append(f'--account-id={account_id}')
 
         setup_and_run(binary_path, home, init_flags, boot_nodes, verbose,
-                      no_watcher)
+                      not no_watcher)
 
 
 @click.option('--keep-watcher', is_flag=True, help='Keep the watcher running.')

--- a/nearup
+++ b/nearup
@@ -99,12 +99,23 @@ def stop(keep_watcher):
 @click.argument('network',
                 type=click.Choice({'mainnet', 'testnet', 'betanet',
                                    'localnet'}))
+@click.option(
+    '--home',
+    type=str,
+    help=
+    'Home path for storing configs, keys and chain data (Default: ~/.near/testnet)'
+)
 @click.option('--restart-watcher',
               is_flag=True,
               help='Restart the watcher as well')
 @cli.command()
 def restart(network, restart_watcher):
-    restart_nearup(network, keep_watcher=not restart_watcher)
+    if home:
+        home = os.path.abspath(home)
+    else:
+        home = os.path.expanduser(f'~/.near/{network}')
+
+    restart_nearup(network, home_dir=home, keep_watcher=not restart_watcher)
 
 
 @click.option('--follow', '-f', is_flag=True, help='Follow the logs.')

--- a/nearuplib/nodelib.py
+++ b/nearuplib/nodelib.py
@@ -209,7 +209,7 @@ def setup_and_run(binary_path,
                   init_flags,
                   boot_nodes,
                   verbose=False,
-                  watcher=False):
+                  watcher=True):
     check_exist_neard()
     chain_id = get_chain_id_from_flags(init_flags)
 

--- a/nearuplib/nodelib.py
+++ b/nearuplib/nodelib.py
@@ -231,6 +231,7 @@ def setup_and_run(binary_path,
         download_binaries(chain_id, uname)
     else:
         logging.info(f'Using local binary at {binary_path}')
+        watcher = False # ensure watcher doesn't run and try to download official binaries
 
     check_and_setup(binary_path, home_dir, init_flags)
 

--- a/nearuplib/nodelib.py
+++ b/nearuplib/nodelib.py
@@ -209,10 +209,9 @@ def setup_and_run(binary_path,
                   init_flags,
                   boot_nodes,
                   verbose=False,
-                  no_watcher=False):
+                  watcher=False):
     check_exist_neard()
     chain_id = get_chain_id_from_flags(init_flags)
-    watch = False
 
     if binary_path == '':
         logging.info('Using officially compiled binary')
@@ -230,18 +229,13 @@ def setup_and_run(binary_path,
             os.makedirs(binary_path)
 
         download_binaries(chain_id, uname)
-        watch = True
     else:
         logging.info(f'Using local binary at {binary_path}')
 
     check_and_setup(binary_path, home_dir, init_flags)
 
     print_staking_key(home_dir)
-
-    if no_watcher:
-        watch = False
-
-    run(home_dir, binary_path, boot_nodes, verbose, chain_id, watch=watch)
+    run(home_dir, binary_path, boot_nodes, verbose, chain_id, watch=watcher)
 
 
 def stop_nearup(keep_watcher=False):
@@ -257,6 +251,7 @@ def stop_nearup(keep_watcher=False):
 
 def restart_nearup(net,
                    path=os.path.expanduser('~/.local/bin/nearup'),
+                   home_dir='',
                    keep_watcher=True):
     logging.warning("Restarting nearup...")
 
@@ -274,11 +269,11 @@ def restart_nearup(net,
 
     logging.warning("Starting nearup...")
     setup_and_run(binary_path='',
-                  home_dir='',
+                  home_dir=home_dir,
                   init_flags=[f'--chain-id={net}'],
                   boot_nodes='',
                   verbose=True,
-                  no_watcher=keep_watcher)
+                  watcher=not keep_watcher)
 
     logging.info("Nearup has been restarted...")
 

--- a/tests/test_nearup_integration_test.py
+++ b/tests/test_nearup_integration_test.py
@@ -9,7 +9,7 @@ from urllib3.util.retry import Retry
 from nearuplib.nodelib import restart_nearup, setup_and_run, stop_nearup
 from nearuplib.constants import LOGS_FOLDER
 
-NEAR_DIR = '~/.near'
+NEAR_DIR = os.path.expanduser('~/.near/betanet')
 NEARUP_DIR = '~/.nearup'
 
 NEARUP_PATH = os.path.join(
@@ -42,11 +42,11 @@ def teardown_module(module):  # pylint: disable=W0613
 
 def test_nearup_still_runnable():
     setup_and_run(binary_path='',
-                  home_dir='',
+                  home_dir=NEAR_DIR,
                   init_flags=['--chain-id=betanet'],
                   boot_nodes='',
                   verbose=True,
-                  no_watcher=True)
+                  watcher=False)
 
     retry_strategy = Retry(total=5, backoff_factor=5)
     http = requests.Session()
@@ -61,7 +61,7 @@ def test_nearup_still_runnable():
     with pytest.raises(requests.exceptions.ConnectionError):
         requests.get('http://localhost:3030/status')
 
-    restart_nearup('betanet', NEARUP_PATH, keep_watcher=True)
+    restart_nearup('betanet', NEARUP_PATH, NEAR_DIR, keep_watcher=True)
 
     resp = http.get('http://localhost:3030/status')
     assert resp.status_code == 200


### PR DESCRIPTION
During investigation of why `genesis.json` and other configuration was written to the `nearup` working directory during testing, I noticed that `setup_and_run` and `restart_nearup` were using an empty string for the home directory when calling into the `near` binary. This seems to have caused the execution to use the _working directory_ (in this case, the `nearup` project) as the directory to dump these `*.json` files.

* Refactored to use named home directories in both cases
* Added `--home` flag to `nearup restart` (will default to `~/.near/{network}`)
* Changed `no_watcher` to `watcher` to line up with the positive assertion that `watcher` should be running (True) or not (False)