### PR TITLE
Release Automation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,6 +104,7 @@ celerybeat.pid
 # Environments
 .env
 .venv
+env
 env/
 venv/
 ENV/

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,7 @@ ENV HOME="/root"
 
 RUN apt-get update && \
     apt-get install -y python3 python3-pip && \
-    pip3 install --upgrade pip && \
-    pip3 install --user tox
+    pip3 install --upgrade pip
 
 COPY . /root/nearup/
 RUN cd /root/nearup && pip3 install --user .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,18 @@
 from ubuntu:18.04
 
-COPY ./nearuplib/VERSION /root/VERSION
-RUN apt-get update && \
-    apt-get install -y python3 python3-pip && \
-    pip3 install --upgrade pip && \
-    pip3 install --user tox && \
-    pip3 install --user nearup==$(echo -n $(cat /root/VERSION))
-
 ENV LANG C.UTF-8
 ENV LC_ALL C.UTF-8
 ENV PATH="/root/.local/bin:$PATH"
 ENV HOME="/root"
+
+RUN apt-get update && \
+    apt-get install -y python3 python3-pip && \
+    pip3 install --upgrade pip && \
+    pip3 install --user tox
+
+COPY . /root/nearup/
+RUN cd /root/nearup && pip3 install --user .
+
 COPY ./start.sh /root/start.sh
 RUN chmod +x /root/start.sh
 

--- a/scripts/docker-release.sh
+++ b/scripts/docker-release.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# CI script: build, tag, and push docker image
+
+set -euo pipefail
+
+IMAGE=nearprotocol/nearup
+VERSION=$(echo -n $(cat nearuplib/VERSION))
+
+echo "logging into docker..."
+echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+
+echo "building latest version $VERSION..."
+docker build . -t $IMAGE:$VERSION
+docker tag $IMAGE:$VERSION $IMAGE:latest
+
+echo "pushing $VERSION as latest..."
+docker push $IMAGE:$VERSION
+docker push $IMAGE:latest
+
+echo "done!"


### PR DESCRIPTION
Resolves #107 

* `nearup-release` pipeline has been created and configured on buildkite
* adds docker image build and release automation, to be executed after the pypi package has been built and released.

The steps on buildkite are,
```
steps:
  - command: "pip3 install --user tox && ~/.local/bin/tox -e build"
    label: "build pypi package"
    timeout: 5

  - wait

  - command: "pip3 install --user tox && ~/.local/bin/tox -e release"
    label: "release pypi package"
    agents:
    - "queue=default"
    timeout: 5

  - command: "scripts/docker-release.sh"
    label: "build and release docker image"
```