### PR TITLE
Fix tox release to PyPI

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -56,13 +56,13 @@ deps =
 commands = python setup.py -q sdist bdist_wheel
 
 [testenv:release]
-passenv = PYPI_USERNAME PYPI_PASSWORD
+passenv = TWINE_USERNAME TWINE_PASSWORD
 deps =
   {[testenv:build]deps}
   twine >= 3.2.0
 commands =
   {[testenv:build]commands}
-  twine upload dist/*
+  twine upload --non-interactive dist/*
 
 [testenv:clean]
 allowlist_externals = rm


### PR DESCRIPTION
After testing the first release via buildkite, we noticed we were passing the wrong env vars. This fixes that and also adds `--non-interactive` so it will not prompt for user/password and fail fast if the env vars aren't set.