### PR TITLE
Remove mainnet as network choice

### DIFF
--- a/nearup
+++ b/nearup
@@ -110,7 +110,7 @@ def stop(keep_watcher):
               is_flag=True,
               help='Restart the watcher as well')
 @cli.command()
-def restart(network, restart_watcher):
+def restart(network, home, restart_watcher):
     if home:
         home = os.path.abspath(home)
     else:

--- a/nearup
+++ b/nearup
@@ -32,8 +32,7 @@ def cli():
 
 @cli.command()
 @click.argument('network',
-                type=click.Choice({'mainnet', 'testnet', 'betanet',
-                                   'localnet'}))
+                type=click.Choice({'testnet', 'betanet', 'localnet'}))
 @click.option(
     '--binary-path',
     type=str,
@@ -78,10 +77,6 @@ def run(network, binary_path, home, account_id, boot_nodes, verbose, num_nodes,
 
     if network == 'localnet':
         entry(binary_path, home, num_nodes, num_shards, override, verbose)
-    elif network == 'mainnet':
-        logging.error('Sorry mainnet is now internal nodes only!!!')
-        logging.error(
-            'Please use https://rpc.mainnet.near.org to reach mainnet rpc')
     else:
         init_flags = [f'--chain-id={network}']
         if account_id:
@@ -98,8 +93,7 @@ def stop(keep_watcher):
 
 
 @click.argument('network',
-                type=click.Choice({'mainnet', 'testnet', 'betanet',
-                                   'localnet'}))
+                type=click.Choice({'testnet', 'betanet', 'localnet'}))
 @click.option(
     '--home',
     type=str,

--- a/watcher
+++ b/watcher
@@ -40,15 +40,11 @@ def run(network):
 
     while True:
         time.sleep(60)
-        try:
-            if latest_deployed_release_commit_has_changed(
-                    network, current_release_commit):
-                logging.info(
-                    "New release has been published. Restarting nearup")
-                restart_nearup(network)
-                current_release_commit = latest_deployed_release_commit(network)
-        except Exception as ex:
-            logging.error(ex)
+        if latest_deployed_release_commit_has_changed(network,
+                                                      current_release_commit):
+            logging.info("New release has been published. Restarting nearup")
+            restart_nearup(network)
+            current_release_commit = latest_deployed_release_commit(network)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Resolves #114 

Like @chefsale mentioned in the linked issue, we do not plan to support `mainnet` in `nearup`. Removed as choice in `nearup run`