### PR TITLE
check is old watcher running via kill(2)

### DIFF
--- a/nearuplib/watcher.py
+++ b/nearuplib/watcher.py
@@ -10,9 +10,30 @@ import psutil
 from nearuplib.constants import DEFAULT_WAIT_TIMEOUT, WATCHER_PID_FILE
 
 
+def check_watcher_file():
+    if not os.path.exists(WATCHER_PID_FILE):
+        return False
+
+    with open(WATCHER_PID_FILE) as pid_file:
+        try:
+            pid = int(pid_file.readline().strip())
+        except Exception:
+            logging.error(f"Nearup watcher PID file {WATCHER_PID_FILE} has unexpected content.")
+            return True
+
+        logging.warning(f"Old Nearup watcher PID file {WATCHER_PID_FILE} found.")
+
+        try:
+            os.kill(pid, 0)
+        except OSError:
+            return False
+        else:
+            logging.error("Nearup watcher is running.")
+            return True
+
+
 def is_watcher_running():
-    if os.path.exists(WATCHER_PID_FILE):
-        logging.error("Nearup watcher is running.")
+    if check_watcher_file():
         logging.error("Run nearup stop or kill the process manually!")
         logging.warning(f"If this is a mistake, remove {WATCHER_PID_FILE}")
         return True


### PR DESCRIPTION
Addresses near/nearup#170

Test plan:

```
$ nearup stop

$ cat /home/mikolaj/.nearup/watcher.pid
841382

$ ls -l /home/mikolaj/.nearup/watcher.pid
-rw-r--r-- 1 mikolaj 5018 6 Feb 23 10:41 /home/mikolaj/.nearup/watcher.pid

$ nearup run testnet
2021-02-23 11:02:25.826 INFO nearup - run: Home directory is /home/mikolaj/.near/testnet...
2021-02-23 11:02:25.826 WARNING watcher - check_watcher_file: Old Nearup watcher PID file /home/mikolaj/.nearup/watcher.pid found.
2021-02-23 11:02:25.826 INFO nodelib - setup_and_run: Using officially compiled binary
2021-02-23 11:02:28.037 INFO util - download_binaries: Downloading latest deployed version for testnet
2021-02-23 11:02:28.037 INFO util - download_binaries: Downloading neard to /home/mikolaj/.nearup/near/testnet/neard from nearcore/Linux/1.18.0/3b70067a4c16d100ea396a5b3144c00aa45a03fd/neard...
2021-02-23 11:02:32.177 INFO util - download_binaries: Downloaded neard to /home/mikolaj/.nearup/near/testnet/neard...
2021-02-23 11:02:32.177 INFO util - download_binaries: Making the neard executable...
2021-02-23 11:02:48.569 INFO nodelib - genesis_changed: The genesis version is up to date
2021-02-23 11:02:50.438 INFO nodelib - print_staking_key: Stake for user 'chorus-one.pool.f863973.m0' with 'ed25519:6LFwyEEsqhuDxorWfsKcPPs324zLWTaoqk4o6RDXN7Qc'
2021-02-23 11:02:50.463 INFO nodelib - run: Node is running...
2021-02-23 11:02:50.464 INFO nodelib - run: To check logs call: `nearup logs` or `nearup logs --follow`
2021-02-23 11:02:50.464 INFO nodelib - run: Watcher is enabled. Starting watcher...
2021-02-23 11:02:50.464 INFO watcher - run_watcher: Starting the nearup watcher...
2021-02-23 11:02:50.464 WARNING watcher - check_watcher_file: Old Nearup watcher PID file /home/mikolaj/.nearup/watcher.pid found.

$ cat /home/mikolaj/.nearup/watcher.pid
841824

$ ls -l /home/mikolaj/.nearup/watcher.pid
-rw-r--r-- 1 mikolaj 5018 6 Feb 23 11:02 /home/mikolaj/.nearup/watcher.pid
```