### PR TITLE
fix: update logging arguments from nearup

### DIFF
--- a/nearup
+++ b/nearup
@@ -65,7 +65,7 @@ def cli():
 @click.option(
     '--neard-log',
     type=str,
-    help='Comma-separated module=level values passed to neard --verbose flag',
+    help='Comma-separated module=level values used to replace the ENV_LOG environment variable',
     default='')
 @click.option('--num-nodes',
               type=int,

--- a/nearuplib/nodelib.py
+++ b/nearuplib/nodelib.py
@@ -145,9 +145,9 @@ def run_binary(path,
     # Note, we need to make these options mutually exclusive
     # for backwards capability reasons, until v1.0.0
     if verbose:
-        env['RUST_LOG'] = 'actix_web'
+        env['RUST_LOG'] = 'debug'
     elif neard_log:
-        command.extend(['--verbose', neard_log])
+        env['RUST_LOG'] = neard_log
 
     command.append(action)
 

--- a/nearuplib/nodelib.py
+++ b/nearuplib/nodelib.py
@@ -145,7 +145,7 @@ def run_binary(path,
     # Note, we need to make these options mutually exclusive
     # for backwards capability reasons, until v1.0.0
     if verbose:
-        env['RUST_LOG'] = 'debug'
+        env['RUST_LOG'] = 'debug,actix_web=info'
     elif neard_log:
         env['RUST_LOG'] = neard_log
 


### PR DESCRIPTION
https://github.com/near/nearup/pull/177 removes the debug directive from logs that would have been there before.

Also, switches from using `--verbose` flag altogether as it will be removed in the future.

Can someone let me know why the `actix_web` directive was added? Is it just so those aren't set as debug? If so, I've made that change