### PR TITLE
fix: typo in help message of verbose flag

### DIFF
--- a/nearup
+++ b/nearup
@@ -66,7 +66,7 @@ def cli():
     '--neard-log',
     type=str,
     help=
-    'Comma-separated module=level values used to replace the ENV_LOG environment variable',
+    'Comma-separated module=level values used to replace the RUST_LOG environment variable',
     default='')
 @click.option('--num-nodes',
               type=int,


### PR DESCRIPTION
oops, was rushing to get PR in before meeting and made this typo, thanks @frol for pointing out!