### PR TITLE
Add --verbose flag to restart command

### DIFF
--- a/nearup
+++ b/nearup
@@ -139,7 +139,8 @@ def restart(network, home, restart_watcher, verbose):
         home = os.path.abspath(home)
     else:
         home = os.path.expanduser(f'~/.near/{network}')
-
+    if network == 'betanet':
+        verbose = True
     restart_nearup(network, home_dir=home, keep_watcher=not restart_watcher, verbose)
 
 

--- a/nearup
+++ b/nearup
@@ -129,14 +129,18 @@ def stop(keep_watcher):
 @click.option('--restart-watcher',
               is_flag=True,
               help='Restart the watcher as well')
+@click.option(
+    '--verbose',
+    is_flag=True,
+    help='If set, prints verbose logs. Betanet always prints verbose logs.')
 @cli.command()
-def restart(network, home, restart_watcher):
+def restart(network, home, restart_watcher, verbose):
     if home:
         home = os.path.abspath(home)
     else:
         home = os.path.expanduser(f'~/.near/{network}')
 
-    restart_nearup(network, home_dir=home, keep_watcher=not restart_watcher)
+    restart_nearup(network, home_dir=home, keep_watcher=not restart_watcher, verbose)
 
 
 @click.option('--follow', '-f', is_flag=True, help='Follow the logs.')

--- a/nearuplib/nodelib.py
+++ b/nearuplib/nodelib.py
@@ -350,7 +350,7 @@ def restart_nearup(net,
                   home_dir=home_dir,
                   chain_id=net,
                   boot_nodes='',
-                  verbose,
+                  verbose=verbose,
                   watcher=not keep_watcher)
 
     logging.info("Nearup has been restarted...")

--- a/nearuplib/nodelib.py
+++ b/nearuplib/nodelib.py
@@ -323,7 +323,8 @@ def stop_nearup(keep_watcher=False):
 def restart_nearup(net,
                    path=os.path.join(site.USER_BASE, 'bin/nearup'),
                    home_dir='',
-                   keep_watcher=True):
+                   keep_watcher=True,
+                   verbose=False):
     logging.warning("Restarting nearup...")
 
     if not os.path.exists(path):
@@ -349,7 +350,7 @@ def restart_nearup(net,
                   home_dir=home_dir,
                   chain_id=net,
                   boot_nodes='',
-                  verbose=False,
+                  verbose,
                   watcher=not keep_watcher)
 
     logging.info("Nearup has been restarted...")

--- a/nearuplib/nodelib.py
+++ b/nearuplib/nodelib.py
@@ -349,7 +349,7 @@ def restart_nearup(net,
                   home_dir=home_dir,
                   chain_id=net,
                   boot_nodes='',
-                  verbose=True,
+                  verbose=False,
                   watcher=not keep_watcher)
 
     logging.info("Nearup has been restarted...")


### PR DESCRIPTION
Currently, the restart command unconditionally sets verbose output
which creates loads of logs that may be undesired by the user.
Similarly to how run command has a --verbose flag add it to restart
command as well.  (And just like in run, the flag is forced to true
when running betanet node).

Fixes: https://github.com/near/nearup/issues/199
