### PR TITLE
Fix --verbose support in `restart` subcommand

### DIFF
--- a/nearup
+++ b/nearup
@@ -147,7 +147,10 @@ def restart(network, home, restart_watcher, verbose):
         home = os.path.expanduser(f'~/.near/{network}')
     if network == 'betanet':
         verbose = True
-    restart_nearup(network, home_dir=home, keep_watcher=not restart_watcher, verbose)
+    restart_nearup(network,
+                   home_dir=home,
+                   keep_watcher=not restart_watcher,
+                   verbose=verbose)
 
 
 @click.option('--follow', '-f', is_flag=True, help='Follow the logs.')


### PR DESCRIPTION
Python syntax error introduced in previous commit caused the script to
fail to star.  Fix the error.

Issue: https://github.com/near/nearup/issues/199