### PR TITLE
Use values set through flags as prompt defaults in interactive mode

### DIFF
--- a/nearuplib/localnet.py
+++ b/nearuplib/localnet.py
@@ -21,12 +21,10 @@ def run(binary_path, home, num_nodes, num_shards, override, verbose=True, intera
             rmtree(home)
     elif interactive:
         print(textwrap.fill(textwrap.dedent("""\
-        Starting localnet NEAR nodes. This is a
-        testnet entirely local to this machine.  Validators and
-        non-validating nodes will be started, and will communicate
-        with each other on localhost, producing blocks on top
-        of a genesis block generated locally.
-        """)))
+        Starting localnet NEAR nodes.  This is a test network entirely local to
+        this machine.  Validators and non-validating nodes will be started, and
+        will communicate with each other on localhost, producing blocks on top
+        of a genesis block generated locally.""")))
         print()
 
     if not os.path.exists(home):

--- a/nearuplib/localnet.py
+++ b/nearuplib/localnet.py
@@ -9,17 +9,14 @@ from shutil import rmtree
 
 from nearuplib.constants import NODE_PID_FILE, LOCALNET_FOLDER, LOCALNET_LOGS_FOLDER
 from nearuplib.nodelib import run_binary, proc_name_from_pid, is_neard_running
-from nearuplib.util import download_binaries, prompt_flag, prompt_bool_flag
+from nearuplib import util
 
 
 def run(binary_path, home, num_nodes, num_shards, override, verbose=True, interactive=False):
     if os.path.exists(home):
-        if interactive:
-            override = prompt_bool_flag(
+        if util.prompt_bool_flag(
                 'Would you like to remove data from the previous localnet run?',
-                '--override',
-                override)
-        if override:
+                override, interactive=interactive):
             logging.info("Removing old data.")
             rmtree(home)
     elif interactive:
@@ -33,21 +30,19 @@ def run(binary_path, home, num_nodes, num_shards, override, verbose=True, intera
         print()
 
     if not os.path.exists(home):
-        num_nodes = prompt_flag(
+        num_nodes = util.prompt_flag(
             'How many validator nodes would you like to initialize this localnet with?',
-            '--num-nodes',
             num_nodes,
-            4,
-            interactive,
+            default=4,
+            interactive=interactive,
             type=int,
         )
-        num_shards = prompt_flag(
+        num_shards = util.prompt_flag(
             'How many shards would you like to initialize this localnet with?'
             '\nSee https://near.org/papers/nightshade/#sharding-basics',
-            '--num-shards',
             num_shards,
-            1,
-            interactive,
+            default=1,
+            interactive=interactive,
             type=int,
         )
         run_binary(binary_path,
@@ -112,7 +107,7 @@ def entry(binary_path, home, num_nodes, num_shards, override, verbose, interacti
         binary_path = os.path.join(LOCALNET_FOLDER, "neard")
         if not os.path.exists(LOCALNET_FOLDER):
             os.makedirs(LOCALNET_FOLDER)
-        download_binaries('localnet', uname)
+        util.download_binaries('localnet', uname)
 
     if is_neard_running():
         sys.exit(1)

--- a/nearuplib/nodelib.py
+++ b/nearuplib/nodelib.py
@@ -72,7 +72,6 @@ def init_near(home_dir, binary_path, chain_id, account_id, interactive=False):
             don\'t already have an account, please see
             https://docs.near.org/docs/develop/basics/create-account"""),
                           width=80, break_on_hyphens=False, break_long_words=False),
-            '--account-id',
             account_id,
             None,
             interactive,

--- a/nearuplib/nodelib.py
+++ b/nearuplib/nodelib.py
@@ -73,8 +73,8 @@ def init_near(home_dir, binary_path, chain_id, account_id, interactive=False):
             https://docs.near.org/docs/develop/basics/create-account"""),
                           width=80, break_on_hyphens=False, break_long_words=False),
             account_id,
-            None,
-            interactive,
+            default=None,
+            interactive=interactive,
             type=str)
     cmd = [f'{binary_path}/neard', f'--home={home_dir}', 'init', f'--chain-id={chain_id}']
     if account_id:

--- a/nearuplib/util.py
+++ b/nearuplib/util.py
@@ -151,20 +151,16 @@ def latest_genesis_md5sum_has_changed(net, md5_sum):
     return latest_md5sum != md5_sum
 
 
-def prompt_bool_flag(msg, flag_name, flag_value):
-    if not flag_value:
-        return click.confirm(msg)
-    return click.confirm(msg + '\nYou gave the {} flag, which without --interactive means \'yes\' here'.format(flag_name))
+def prompt_bool_flag(msg, value, *, interactive):
+    if interactive:
+        value = click.confirm(msg, default=bool(value))
+    return bool(value)
 
 
-def prompt_flag(msg, flag_name, flag_value, default_value, interactive, type=str):
-    if not interactive:
-        if flag_value is None:
-            return default_value
-        else:
-            return flag_value
-
-    if flag_value is None:
-        return click.prompt(msg, type=type, default=default_value)
-    return click.prompt(msg + '\nYou gave {}={}.'.format(flag_name, flag_value),
-                        type=type, default=default_value)
+def prompt_flag(msg, flag_value, *, default, interactive, type=str):
+    value = default
+    if flag_value is not None:
+        value = flag_value
+    if interactive:
+        value = click.prompt(msg, type=type, default=value)
+    return value


### PR DESCRIPTION
Rather than writing out what user passed through a flag and forcing
them to type it again, make the customisation the default in the
prompt so that user can just confirm it by pressing Return.  This also
simplifies the code since bunch of message formatting special cases
are eliminated.