### PR TITLE
Added new options: fixed-shards and archival-nodes

### DIFF
--- a/nearuplib/localnet.py
+++ b/nearuplib/localnet.py
@@ -52,11 +52,25 @@ def run(binary_path,
             interactive=interactive,
             type=int,
         )
+        fixed_shards = False
+        if num_shards > 1:
+            fixed_shards = util.prompt_bool_flag(
+                'Would you like to setup fixed accounts per each shard (shard0.test.near, shard1.test.near etc)?',
+                False,
+                interactive=interactive,
+            )
+        archival_nodes = util.prompt_bool_flag(
+            "Should these nodes be archival nodes (keep full history)?",
+            False,
+            interactive=interactive)
+
         run_binary(binary_path,
                    home,
-                   'testnet',
+                   'localnet',
                    shards=num_shards,
                    validators=num_nodes,
+                   fixed_shards=fixed_shards,
+                   archival_nodes=archival_nodes,
                    print_command=interactive).wait()
 
     # Edit args files

--- a/nearuplib/localnet.py
+++ b/nearuplib/localnet.py
@@ -55,7 +55,7 @@ def run(binary_path,
         fixed_shards = False
         if num_shards > 1:
             fixed_shards = util.prompt_bool_flag(
-                'Would you like to setup fixed accounts per each shard (shard0.test.near, shard1.test.near etc)?',
+                'Would you like to setup fixed accounts per each shard (shard0, shard1)?',
                 False,
                 interactive=interactive,
             )

--- a/nearuplib/nodelib.py
+++ b/nearuplib/nodelib.py
@@ -215,9 +215,9 @@ def run_binary(path,
     if boot_nodes:
         command.extend(['--boot-nodes', boot_nodes])
     if fixed_shards:
-        command.extend(['--fixed-shards'])
+        command.append('--fixed-shards')
     if archival_nodes:
-        command.extend(['--archival-nodes'])
+        command.append('--archival-nodes')
 
     if output:
         logname = f'{output}.log'

--- a/nearuplib/nodelib.py
+++ b/nearuplib/nodelib.py
@@ -10,16 +10,10 @@ import sys
 import psutil
 
 from nearuplib.constants import DEFAULT_WAIT_TIMEOUT, LOGS_FOLDER, NODE_PID_FILE
-from nearuplib.util import (
-    download_binaries,
-    download_config,
-    download_genesis,
-    latest_genesis_md5sum,
-    new_release_ready,
-    prompt_bool_flag,
-    prompt_flag,
-    wraptext
-)
+from nearuplib.util import (download_binaries, download_config,
+                            download_genesis, latest_genesis_md5sum,
+                            new_release_ready, prompt_bool_flag, prompt_flag,
+                            wraptext)
 from nearuplib.watcher import is_watcher_running, run_watcher, stop_watcher
 from nearuplib.tailer import next_logname
 
@@ -40,7 +34,8 @@ def print_validator_info(home_dir):
         return
 
     print()
-    print(wraptext(f'''
+    print(
+        wraptext(f'''
         The validator’s public key is {key_data["public_key"]}
 
         The node will now run and will sync with the network, but this will not
@@ -75,12 +70,18 @@ def init_near(home_dir, binary_path, chain_id, account_id, interactive=False):
             account, please see
             https://docs.near.org/docs/develop/basics/create-account
         '''
-        account_id = prompt_flag(msg, account_id, default=None,
-                                 interactive=interactive, type=str)
+        account_id = prompt_flag(msg,
+                                 account_id,
+                                 default=None,
+                                 interactive=interactive,
+                                 type=str)
     else:
         account_id = None
 
-    cmd = [f'{binary_path}/neard', f'--home={home_dir}', 'init', f'--chain-id={chain_id}']
+    cmd = [
+        f'{binary_path}/neard', f'--home={home_dir}', 'init',
+        f'--chain-id={chain_id}'
+    ]
     if account_id:
         cmd.append(f'--account-id={account_id}')
     if chain_id in ['betanet', 'testnet']:
@@ -127,7 +128,11 @@ def check_and_update_genesis(chain_id, home_dir):
     return False
 
 
-def check_and_setup(binary_path, home_dir, chain_id, account_id, interactive=False):
+def check_and_setup(binary_path,
+                    home_dir,
+                    chain_id,
+                    account_id,
+                    interactive=False):
     """Checks if there is already everything setup on this machine, otherwise sets up NEAR node."""
     if os.path.exists(os.path.join(home_dir)):
         if chain_id != 'localnet':
@@ -184,7 +189,9 @@ def run_binary(path,
                non_validators=None,
                boot_nodes=None,
                output=None,
-               print_command=False):
+               print_command=False,
+               fixed_shards=False,
+               archival_nodes=False):
     command = [path, '--home', str(home)]
 
     env = os.environ.copy()
@@ -207,6 +214,10 @@ def run_binary(path,
         command.extend(['--n', str(non_validators)])
     if boot_nodes:
         command.extend(['--boot-nodes', boot_nodes])
+    if fixed_shards:
+        command.extend(['--fixed-shards'])
+    if archival_nodes:
+        command.extend(['--archival-nodes'])
 
     if output:
         logname = f'{output}.log'

--- a/tox.ini
+++ b/tox.ini
@@ -44,7 +44,8 @@ disable=missing-module-docstring,
         duplicate-code,
         too-many-arguments,
         consider-using-with,
-        unspecified-encoding
+        unspecified-encoding,
+	      too-many-locals,
 
 [DESIGN]
 # Maximum number of arguments for function / method


### PR DESCRIPTION
Added support for two new options in localnet creation:
- setting archival node
- fixed_shards - that would create genesis file with accounts that belong to each shard.

see nearcore/6658 PR that adds those options.