### PR TITLE
Add fix_accounts option

### DIFF
--- a/nearup
+++ b/nearup
@@ -89,11 +89,14 @@ def cli():
 @click.option('--override',
               is_flag=True,
               help='Override previous localnet node data if exists')
+@click.option('--fix-accounts',
+              is_flag=True,
+              help='Setup fixed accounts for first (N-1) shards (shard0, shard1, ...)')
 @click.option('--no-watcher',
               is_flag=True,
               help='Disable nearup watcher, mostly used for tests.')
 def run(network, binary_path, home, account_id, boot_nodes, interactive,
-        verbose, neard_log, num_nodes, num_shards, override, no_watcher):
+        verbose, neard_log, num_nodes, num_shards, override, fix_accounts, no_watcher):
     if home:
         home = os.path.abspath(home)
     else:
@@ -105,7 +108,7 @@ def run(network, binary_path, home, account_id, boot_nodes, interactive,
         verbose = True
 
     if network == 'localnet':
-        entry(binary_path, home, num_nodes, num_shards, override, verbose,
+        entry(binary_path, home, num_nodes, num_shards, override, fix_accounts, verbose,
               interactive)
     else:
         setup_and_run(binary_path,

--- a/nearuplib/localnet.py
+++ b/nearuplib/localnet.py
@@ -15,6 +15,7 @@ def run(binary_path,
         num_nodes,
         num_shards,
         override,
+        fix_accounts,
         verbose=True,
         interactive=False):
     home = pathlib.Path(home)
@@ -55,8 +56,8 @@ def run(binary_path,
         fixed_shards = False
         if num_shards > 1:
             fixed_shards = util.prompt_bool_flag(
-                'Would you like to setup fixed accounts per each shard (shard0, shard1)?',
-                False,
+                'Would you like to setup fixed accounts for first (N-1) shards (shard0, shard1, ...)?',
+                fix_accounts,
                 interactive=interactive,
             )
         archival_nodes = util.prompt_bool_flag(
@@ -113,7 +114,7 @@ def run(binary_path,
     logging.info('Check localnet status at http://127.0.0.1:3030/status')
 
 
-def entry(binary_path, home, num_nodes, num_shards, override, verbose,
+def entry(binary_path, home, num_nodes, num_shards, override, fix_accounts, verbose,
           interactive):
     if binary_path:
         binary_path = os.path.join(binary_path, 'neard')
@@ -127,5 +128,5 @@ def entry(binary_path, home, num_nodes, num_shards, override, verbose,
     if is_neard_running():
         sys.exit(1)
 
-    run(binary_path, home, num_nodes, num_shards, override, verbose,
+    run(binary_path, home, num_nodes, num_shards, override, fix_accounts, verbose,
         interactive)


### PR DESCRIPTION
Add an option to create fixed accounts for localnet, which was previously available only on interactive mode.
Fix the message by saying that only for (N-1) shards fixed accounts are created.