### PR TITLE
Adding --archival and --tracked-shards

### DIFF
--- a/nearup
+++ b/nearup
@@ -90,13 +90,13 @@ def cli():
     '--num-nodes',
     type=int,
     help=
-    'Specifies the number of nodes to create. Only applicable to localnet. Will be ignored if --interactive is used.'
+    'The number of nodes to create. Only applicable to localnet. Will be ignored if --interactive is used.'
 )
 @click.option(
     '--num-shards',
     type=int,
     help=
-    'Specifies the number of shards to create. Only applicable to localnet. Will be ignored if --interactive is used.'
+    'The number of shards to create. Only applicable to localnet. Will be ignored if --interactive is used.'
 )
 @click.option(
     '--fix-accounts',

--- a/nearup
+++ b/nearup
@@ -110,12 +110,18 @@ def cli():
     help=
     'Setup the nodes to be archival (keep full history). Only applicable to localnet. Will be ignored if --interactive is used.'
 )
+@click.option(
+    '--tracked-shards',
+    type=str,
+    help=
+    'Comma separated list of shards to track, the word \'all\' to track all shards or the word \'none\' to track no shards.'
+    'Only applicable to localnet. Will be ignored if --interactive is used.')
 @click.option('--no-watcher',
               is_flag=True,
               help='Disable nearup watcher, mostly used for tests.')
 def run(network, binary_path, home, account_id, boot_nodes, interactive,
         verbose, neard_log, override, num_nodes, num_shards, fix_accounts,
-        archival_nodes, no_watcher):
+        archival_nodes, tracked_shards, no_watcher):
     if home:
         home = os.path.abspath(home)
     else:
@@ -128,7 +134,7 @@ def run(network, binary_path, home, account_id, boot_nodes, interactive,
 
     if network == 'localnet':
         entry(binary_path, home, num_nodes, num_shards, override, fix_accounts,
-              archival_nodes, verbose, interactive)
+              archival_nodes, tracked_shards, verbose, interactive)
     else:
         setup_and_run(binary_path,
                       home,

--- a/nearup
+++ b/nearup
@@ -80,23 +80,42 @@ def cli():
           'verbosity.  Deprecated: Prefer setting RUST_LOG environment '
           'variable instead.'),
     default='')
-@click.option('--num-nodes',
-              type=int,
-              help='Specifies the number of localnet nodes to create')
-@click.option('--num-shards',
-              type=int,
-              help='Specifies the number of localnet shards to create')
-@click.option('--override',
-              is_flag=True,
-              help='Override previous localnet node data if exists')
-@click.option('--fix-accounts',
-              is_flag=True,
-              help='Setup fixed accounts for first (N-1) shards (shard0, shard1, ...)')
+@click.option(
+    '--override',
+    is_flag=True,
+    help=
+    'Override previous node data if exists. Only applicable to localnet. Will be ignored if --interactive is used.'
+)
+@click.option(
+    '--num-nodes',
+    type=int,
+    help=
+    'Specifies the number of nodes to create. Only applicable to localnet. Will be ignored if --interactive is used.'
+)
+@click.option(
+    '--num-shards',
+    type=int,
+    help=
+    'Specifies the number of shards to create. Only applicable to localnet. Will be ignored if --interactive is used.'
+)
+@click.option(
+    '--fix-accounts',
+    is_flag=True,
+    help=
+    'Setup fixed accounts for first (N-1) shards (shard0, shard1, ...). Only applicable to localnet. Will be ignored if --interactive is used.'
+)
+@click.option(
+    '--archival-nodes',
+    is_flag=True,
+    help=
+    'Setup the nodes to be archival (keep full history). Only applicable to localnet. Will be ignored if --interactive is used.'
+)
 @click.option('--no-watcher',
               is_flag=True,
               help='Disable nearup watcher, mostly used for tests.')
 def run(network, binary_path, home, account_id, boot_nodes, interactive,
-        verbose, neard_log, num_nodes, num_shards, override, fix_accounts, no_watcher):
+        verbose, neard_log, override, num_nodes, num_shards, fix_accounts,
+        archival_nodes, no_watcher):
     if home:
         home = os.path.abspath(home)
     else:
@@ -108,8 +127,8 @@ def run(network, binary_path, home, account_id, boot_nodes, interactive,
         verbose = True
 
     if network == 'localnet':
-        entry(binary_path, home, num_nodes, num_shards, override, fix_accounts, verbose,
-              interactive)
+        entry(binary_path, home, num_nodes, num_shards, override, fix_accounts,
+              archival_nodes, verbose, interactive)
     else:
         setup_and_run(binary_path,
                       home,

--- a/nearuplib/localnet.py
+++ b/nearuplib/localnet.py
@@ -17,6 +17,7 @@ def run(binary_path,
         override,
         fix_accounts,
         archival_nodes,
+        tracked_shards,
         verbose=True,
         interactive=False):
     home = pathlib.Path(home)
@@ -65,6 +66,11 @@ def run(binary_path,
             "Should these nodes be archival nodes (keep full history)?",
             archival_nodes,
             interactive=interactive)
+        tracked_shards = util.prompt_flag(
+            "What shards should be tracked? Comma separated list of shards to track, the word \'all\' to track all shards or the word \'none\' to track no shards.",
+            tracked_shards,
+            interactive=interactive,
+            default="all")
 
         run_binary(binary_path,
                    home,
@@ -73,6 +79,7 @@ def run(binary_path,
                    validators=num_nodes,
                    fixed_shards=fixed_shards,
                    archival_nodes=archival_nodes,
+                   tracked_shards=tracked_shards,
                    print_command=interactive).wait()
 
     # Edit args files
@@ -115,8 +122,8 @@ def run(binary_path,
     logging.info('Check localnet status at http://127.0.0.1:3030/status')
 
 
-def entry(binary_path, home, num_nodes, num_shards, override, fix_accounts, archival_nodes,
-          verbose, interactive):
+def entry(binary_path, home, num_nodes, num_shards, override, fix_accounts,
+          archival_nodes, tracked_shards, verbose, interactive):
     if binary_path:
         binary_path = os.path.join(binary_path, 'neard')
     else:
@@ -129,5 +136,5 @@ def entry(binary_path, home, num_nodes, num_shards, override, fix_accounts, arch
     if is_neard_running():
         sys.exit(1)
 
-    run(binary_path, home, num_nodes, num_shards, override, fix_accounts, archival_nodes,
-        verbose, interactive)
+    run(binary_path, home, num_nodes, num_shards, override, fix_accounts,
+        archival_nodes, tracked_shards, verbose, interactive)

--- a/nearuplib/localnet.py
+++ b/nearuplib/localnet.py
@@ -16,6 +16,7 @@ def run(binary_path,
         num_shards,
         override,
         fix_accounts,
+        archival_nodes,
         verbose=True,
         interactive=False):
     home = pathlib.Path(home)
@@ -62,7 +63,7 @@ def run(binary_path,
             )
         archival_nodes = util.prompt_bool_flag(
             "Should these nodes be archival nodes (keep full history)?",
-            False,
+            archival_nodes,
             interactive=interactive)
 
         run_binary(binary_path,
@@ -114,8 +115,8 @@ def run(binary_path,
     logging.info('Check localnet status at http://127.0.0.1:3030/status')
 
 
-def entry(binary_path, home, num_nodes, num_shards, override, fix_accounts, verbose,
-          interactive):
+def entry(binary_path, home, num_nodes, num_shards, override, fix_accounts, archival_nodes,
+          verbose, interactive):
     if binary_path:
         binary_path = os.path.join(binary_path, 'neard')
     else:
@@ -128,5 +129,5 @@ def entry(binary_path, home, num_nodes, num_shards, override, fix_accounts, verb
     if is_neard_running():
         sys.exit(1)
 
-    run(binary_path, home, num_nodes, num_shards, override, fix_accounts, verbose,
-        interactive)
+    run(binary_path, home, num_nodes, num_shards, override, fix_accounts, archival_nodes,
+        verbose, interactive)

--- a/nearuplib/nodelib.py
+++ b/nearuplib/nodelib.py
@@ -193,7 +193,8 @@ def run_binary(path,
                output=None,
                print_command=False,
                fixed_shards=False,
-               archival_nodes=False):
+               archival_nodes=False,
+               tracked_shards=False):
     command = [path, '--home', str(home)]
 
     env = os.environ.copy()
@@ -220,6 +221,8 @@ def run_binary(path,
         command.append('--fixed-shards')
     if archival_nodes:
         command.append('--archival-nodes')
+    if tracked_shards:
+        command.extend(['--tracked-shards', tracked_shards])
 
     if output:
         logname = f'{output}.log'
@@ -241,8 +244,7 @@ def proc_name_from_pid(pid):
 def is_neard_running():
     if os.path.exists(NODE_PID_FILE):
         logging.error("There is already binary nodes running.")
-        logging.error(
-            "Either run nearup stop or by kill the process manually.")
+        logging.error("Either run nearup stop or by kill the process manually.")
         logging.warning(f"If this is a mistake, remove {NODE_PID_FILE}")
         return True
     return False
@@ -287,6 +289,9 @@ def setup_and_run(binary_path,
                   interactive=False,
                   neard_log='',
                   watcher=True):
+    logging.info(
+        f'setup and run, chain_id: {chain_id} binary_path: {binary_path}')
+
     if is_neard_running():
         sys.exit(1)
 
@@ -417,7 +422,9 @@ def is_neard_zombie():
                 logging.info(f"Near procces is {proc_name} with pid: {pid}...")
                 if proc_name not in process.name():
                     return True
-                if process.status() in [psutil.STATUS_ZOMBIE, psutil.STATUS_DEAD]:
+                if process.status() in [
+                        psutil.STATUS_ZOMBIE, psutil.STATUS_DEAD
+                ]:
                     return True
             except psutil.NoSuchProcess:
                 return True

--- a/nearuplib/nodelib.py
+++ b/nearuplib/nodelib.py
@@ -241,7 +241,8 @@ def proc_name_from_pid(pid):
 def is_neard_running():
     if os.path.exists(NODE_PID_FILE):
         logging.error("There is already binary nodes running.")
-        logging.error("Either run nearup stop or by kill the process manually.")
+        logging.error(
+            "Either run nearup stop or by kill the process manually.")
         logging.warning(f"If this is a mistake, remove {NODE_PID_FILE}")
         return True
     return False

--- a/tests/test_nearup_integration_test.py
+++ b/tests/test_nearup_integration_test.py
@@ -1,5 +1,6 @@
 import os
 import shutil
+import json
 
 import pytest
 import requests
@@ -8,8 +9,12 @@ from urllib3.util.retry import Retry
 
 from nearuplib.nodelib import restart_nearup, setup_and_run, stop_nearup
 from nearuplib.constants import LOGS_FOLDER
+from nearuplib.localnet import entry
+from nearuplib.util import download_binaries
 
-NEAR_DIR = os.path.expanduser('~/.near/betanet')
+BETANET_NEAR_DIR = os.path.expanduser('~/.near/betanet')
+LOCALNET_NEAR_DIR = os.path.expanduser('~/.near/localnet')
+BINARY_DIR = os.path.expanduser('~/.nearup/near/betanet')
 NEARUP_DIR = '~/.nearup'
 
 NEARUP_PATH = os.path.join(
@@ -19,8 +24,12 @@ NEARUP_PATH = os.path.join(
 
 
 def cleanup():
-    if os.path.exists(NEAR_DIR):
-        shutil.rmtree(NEAR_DIR)
+    print("cleanup")
+    if os.path.exists(BETANET_NEAR_DIR):
+        shutil.rmtree(BETANET_NEAR_DIR)
+
+    if os.path.exists(LOCALNET_NEAR_DIR):
+        shutil.rmtree(LOCALNET_NEAR_DIR)
 
     if os.path.exists(NEARUP_DIR):
         shutil.rmtree(NEARUP_DIR)
@@ -30,6 +39,8 @@ def cleanup():
 
 
 def setup_module(module):  # pylint: disable=W0613
+    print()
+    print("setup")
     cleanup()
 
     if not os.path.exists(LOGS_FOLDER):
@@ -40,9 +51,23 @@ def teardown_module(module):  # pylint: disable=W0613
     cleanup()
 
 
-def test_nearup_still_runnable():
+def download_betanet_binary(dir):
+    uname = os.uname()[0]
+    download_binaries('betanet', uname)
+
+    expected_binary = 'neard'
+    path = os.path.join(dir, expected_binary)
+
+    # check if the binary exists
+    assert os.path.exists(path)
+
+    # check if the binary is executable
+    assert os.access(path, os.X_OK)
+
+
+def test_nearup_still_runnable_betanet():
     setup_and_run(binary_path='',
-                  home_dir=NEAR_DIR,
+                  home_dir=BETANET_NEAR_DIR,
                   chain_id='betanet',
                   boot_nodes='',
                   verbose=True,
@@ -61,7 +86,7 @@ def test_nearup_still_runnable():
     with pytest.raises(requests.exceptions.ConnectionError):
         requests.get('http://localhost:3030/status')
 
-    restart_nearup('betanet', NEARUP_PATH, NEAR_DIR, keep_watcher=True)
+    restart_nearup('betanet', NEARUP_PATH, BETANET_NEAR_DIR, keep_watcher=True)
 
     resp = http.get('http://localhost:3030/status')
     assert resp.status_code == 200
@@ -71,3 +96,62 @@ def test_nearup_still_runnable():
 
     with pytest.raises(requests.exceptions.ConnectionError):
         requests.get('http://localhost:3030/status')
+
+
+def test_nearup_still_runnable_localnet():
+    # use betanet binary because downloading localnet doesn't work so well
+    download_betanet_binary(BINARY_DIR)
+
+    n = 4
+    entry(binary_path=BINARY_DIR,
+          home=LOCALNET_NEAR_DIR,
+          num_nodes=n,
+          num_shards=n,
+          override=True,
+          fix_accounts=True,
+          archival_nodes=True,
+          verbose=True,
+          interactive=False)
+
+    retry_strategy = Retry(total=5, backoff_factor=5)
+    http = requests.Session()
+    http.mount("http://", HTTPAdapter(max_retries=retry_strategy))
+
+    for i in range(n):
+        print(f"Checking the config of the {i}th node")
+        config_path = os.path.join(LOCALNET_NEAR_DIR, f"node{i}", "config.json")
+        assert os.path.exists(config_path)
+
+        with open(config_path) as file:
+            config = json.load(file)
+            # test the --archival-nodes argument
+            assert config['archive'] == True
+
+    for i in range(n):
+        print(f"Checking the genesis of the {i}th node")
+        genesis_path = os.path.join(LOCALNET_NEAR_DIR, f"node{i}",
+                                    "genesis.json")
+        assert os.path.exists(genesis_path)
+
+        with open(genesis_path) as file:
+            genesis = json.load(file)
+            # test the --num-nodes argument
+            assert len(genesis['validators']) == 4
+            # test the --fixed-accounts argument
+            assert genesis['shard_layout']["V1"]["fixed_shards"] == [
+                "shard0", "shard1", "shard2"
+            ]
+
+    for i in range(n):
+        print(f"Checking the status of the {i}th node.")
+        port = 3030 + i
+        resp = http.get(f'http://localhost:{port}/status')
+        assert resp.status_code == 200
+        assert resp.text
+
+    stop_nearup(keep_watcher=True)
+
+    for i in range(n):
+        with pytest.raises(requests.exceptions.ConnectionError):
+            port = 3030 + i
+            requests.get(f'http://localhost:{port}/status')

--- a/tests/test_nearup_integration_test.py
+++ b/tests/test_nearup_integration_test.py
@@ -127,7 +127,7 @@ def test_nearup_still_runnable_localnet():
     http.mount("http://", HTTPAdapter(max_retries=retry_strategy))
 
     for i in range(n):
-        print(f"Checking the config of the {i}th node")
+        logging.info(f"Checking the config of the {i}th node")
         config_path = os.path.join(LOCALNET_NEAR_DIR, f"node{i}", "config.json")
         assert os.path.exists(config_path)
 
@@ -137,7 +137,7 @@ def test_nearup_still_runnable_localnet():
             assert config['archive'] == True
 
     for i in range(n):
-        print(f"Checking the genesis of the {i}th node")
+        logging.info(f"Checking the genesis of the {i}th node")
         genesis_path = os.path.join(LOCALNET_NEAR_DIR, f"node{i}",
                                     "genesis.json")
         assert os.path.exists(genesis_path)
@@ -152,7 +152,7 @@ def test_nearup_still_runnable_localnet():
             ]
 
     for i in range(n):
-        print(f"Checking the status of the {i}th node.")
+        logging.info(f"Checking the status of the {i}th node.")
         port = 3030 + i
         resp = http.get(f'http://localhost:{port}/status')
         assert resp.status_code == 200


### PR DESCRIPTION
Adding new cmdline arguments to allow the localnet nodes to be configured as archival and to configure the tracked shards. It may come in handy when testing larger numbers of nodes / shards. 