### PR TITLE
feat: save the genesis hash in a file and handle a separate records file

### DIFF
--- a/tests/test_download_binaries.py
+++ b/tests/test_download_binaries.py
@@ -2,7 +2,7 @@ import json
 import os
 import shutil
 
-from nearuplib.util import download_binaries, download_config, download_genesis
+from nearuplib.util import download_binaries, download_genesis
 
 HOME_DIR = os.path.expanduser('~/.near/betanet')
 NEARUP_BINARY_DIR = os.path.expanduser('~/.nearup/near/betanet')
@@ -31,15 +31,6 @@ def test_download_binaries():
 
     # check if the binary is executable
     assert os.access(path, os.X_OK)
-
-
-def test_download_config():
-    download_config('betanet', HOME_DIR)
-    path = os.path.join(HOME_DIR, 'config.json')
-
-    assert os.path.exists(path)
-    with open(path) as config:
-        json.loads(config.read())
 
 
 def test_download_genesis():

--- a/watcher
+++ b/watcher
@@ -18,7 +18,7 @@ from nearuplib.util import (
     latest_deployed_release_commit,
     latest_deployed_release_commit_has_changed,
     latest_genesis_md5sum,
-    latest_genesis_md5sum_has_changed,
+    read_genesis_md5sum,
 )
 
 logging.basicConfig(
@@ -52,24 +52,27 @@ def main():
 def run(network, home, force_restart):
     current_release_commit = latest_deployed_release_commit(network)
     # Don't assume that the node has an up-to-date version of genesis.
-    # Instead get hash of the local genesis.
-    with open(os.path.join(home, 'genesis.json'), 'rb') as genesis_fd:
-        current_genesis_md5sum = hashlib.md5(genesis_fd.read()).hexdigest()
+    # Instead read the md5sum hash of the genesis that existed when we initialized home.
+    current_genesis_md5sum = read_genesis_md5sum(network)
+
     logging.info(
         f"Starting watcher for chain: {network} with commit: {current_release_commit}"
     )
 
     if is_neard_zombie():
-        logging.warning("Detected that neard is dead when starting watcher. Restarting neard.")
+        logging.warning(
+            "Detected that neard is dead when starting watcher. Restarting neard."
+        )
         restart_nearup(network, home_dir=home, restart_only_new_version=False)
 
     while True:
         time.sleep(60)
         try:
+            genesis_md5sum = latest_genesis_md5sum(network)
+
             if latest_deployed_release_commit_has_changed(
                     network, current_release_commit
-            ) or latest_genesis_md5sum_has_changed(
-                    network, current_genesis_md5sum) or force_restart:
+            ) or genesis_md5sum != current_genesis_md5sum or force_restart:
                 logging.info(
                     "New release has been published. Restarting nearup")
 
@@ -77,9 +80,10 @@ def run(network, home, force_restart):
                                home_dir=home,
                                restart_only_new_version=False)
                 current_release_commit = latest_deployed_release_commit(network)
-                current_genesis_md5sum = latest_genesis_md5sum(network)
+                current_genesis_md5sum = genesis_md5sum
             elif is_neard_zombie():
-                logging.warning("Detected that neard has died. Restarting neard.")
+                logging.warning(
+                    "Detected that neard has died. Restarting neard.")
                 restart_nearup(network,
                                home_dir=home,
                                restart_only_new_version=False)


### PR DESCRIPTION
currently nearup computes an md5 hash of the genesis file every time it starts up, and compares that to the published hash. This leads to a problem where it will unnecessarily delete the data dir after the first time we start, since neard init rewrites the genesis file with slight changes: https://github.com/near/nearup/issues/228

So instead of computing the hash every time, we will record the published hash in {home_dir}/.nearup/genesis_md5sum when initializing the home directory, and we'll read from that to see if the published version has changed. This also lets us handle the case where the published genesis is using a separate records file, which is something that may happen in the near future because it would speed up start up times significantly

At the same time, we'll remove the download_config() function and just use the --download-config argument to neard init