### PR TITLE
fix directory passed to read_genesis_md5sum() in watcher

### DIFF
--- a/watcher
+++ b/watcher
@@ -53,7 +53,7 @@ def run(network, home, force_restart):
     current_release_commit = latest_deployed_release_commit(network)
     # Don't assume that the node has an up-to-date version of genesis.
     # Instead read the md5sum hash of the genesis that existed when we initialized home.
-    current_genesis_md5sum = read_genesis_md5sum(network)
+    current_genesis_md5sum = read_genesis_md5sum(home)
 
     logging.info(
         f"Starting watcher for chain: {network} with commit: {current_release_commit}"


### PR DESCRIPTION
https://github.com/near/nearup/pull/229 added a read_genesis_md5sum() function that checks for the cached genesis md5sum we're running with, but accidentally passed the wrong argument to it in the watcher, which causes unnecessary restarts